### PR TITLE
Refactor controller.go to finish use of SharedIndexInformer and WorkQueue, add namespace, persistent volume and job to resource types

### DIFF
--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -17,17 +17,17 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/skippbox/kubewatch/config"
 	"github.com/Sirupsen/logrus"
+	"github.com/skippbox/kubewatch/config"
+	"github.com/spf13/cobra"
 )
 
 // resourceConfigCmd represents the resource subcommand
 var resourceConfigCmd = &cobra.Command{
 	Use:   "resource FLAG",
 	Short: "specific resources to be watched",
-	Long: `specific resources to be watched`,
-	Run: func(cmd *cobra.Command, args []string){
+	Long:  `specific resources to be watched`,
+	Run: func(cmd *cobra.Command, args []string) {
 		conf, err := config.New()
 		if err != nil {
 			logrus.Fatal(err)
@@ -69,6 +69,27 @@ var resourceConfigCmd = &cobra.Command{
 			logrus.Fatal("rc", err)
 		}
 
+		b, err = cmd.Flags().GetBool("ns")
+		if err == nil {
+			conf.Resource.Namespace = b
+		} else {
+			logrus.Fatal("ns", err)
+		}
+
+		b, err = cmd.Flags().GetBool("jobs")
+		if err == nil {
+			conf.Resource.Job = b
+		} else {
+			logrus.Fatal("jobs", err)
+		}
+
+		b, err = cmd.Flags().GetBool("pv")
+		if err == nil {
+			conf.Resource.PersistentVolume = b
+		} else {
+			logrus.Fatal("pv", err)
+		}
+
 		if err = conf.Write(); err != nil {
 			logrus.Fatal(err)
 		}
@@ -81,4 +102,8 @@ func init() {
 	resourceConfigCmd.Flags().Bool("po", false, "watch for pods")
 	resourceConfigCmd.Flags().Bool("rc", false, "watch for replication controllers")
 	resourceConfigCmd.Flags().Bool("rs", false, "watch for replicasets")
+	resourceConfigCmd.Flags().Bool("ns", false, "watch for namespaces")
+	resourceConfigCmd.Flags().Bool("pv", false, "watch for persistent volumes")
+	resourceConfigCmd.Flags().Bool("jobs", false, "watch for jobs")
+
 }

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type Resource struct {
 	Pod                   bool `json:"po"`
 	Job                   bool `json:"job"`
 	PersistentVolume      bool `json:"pv"`
+	Namespace	      bool `json:"ns"`
 }
 
 // Config struct contains kubewatch configuration
@@ -123,6 +124,9 @@ func (c *Config) CheckMissingResourceEnvvars() {
 	}
 	if !c.Resource.ReplicaSet && os.Getenv("KW_REPLICASET") == "true" {
 		c.Resource.ReplicaSet = true
+	}
+	if !c.Resource.Namespace && os.Getenv("KW_NAMESPACE") == "true" {
+		c.Resource.Namespace = true
 	}
 	if !c.Resource.Deployment && os.Getenv("KW_DEPLOYMENT") == "true" {
 		c.Resource.Deployment = true

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -51,6 +51,11 @@ func New(obj interface{}, action string) Event {
 		component = string(apiService.Spec.Type)
 		reason = action
 		status = m[action]
+	} else if apiNamespace, ok := obj.(*v1.Namespace); ok {
+		name = apiNamespace.Name
+		kind = "namespace"
+		reason = action
+		status = m[action]
 	} else if apiPod, ok := obj.(*v1.Pod); ok {
 		namespace = apiPod.ObjectMeta.Namespace
 		name = apiPod.Name


### PR DESCRIPTION
This PR finishes refactoring controller.go to use SharedIndexInformer and WorkQueue to monitor resource types. Then finish adding persistent volume, job and namespace resources for monitoring.