### PR TITLE
Code Cleanup and Deployment Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Kubewatch
-[![Build Status](https://travis-ci.org/skippbox/kubewatch.svg?branch=master)](https://travis-ci.org/skippbox/kubewatch) [![Join us on Slack](https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png)](https://skippbox.herokuapp.com)
+[![Build Status](https://travis-ci.org/bitnami-labs/kubewatch.svg?branch=master)](https://travis-ci.org/bitnami-labs/kubewatch) [![Join us on Slack](https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png)](https://skippbox.herokuapp.com)
 
 `kubewatch` is a Kubernetes watcher that currently publishes notification to Slack. Run it in your k8s cluster, and you will get event notifications in a slack channel.
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -14,9 +14,9 @@ limitations under the License.
 package event
 
 import (
+	apps_v1beta1 "k8s.io/api/apps/v1beta1"
 	batch_v1 "k8s.io/api/batch/v1"
 	api_v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 )
 
 // Event represent an event got from k8s api server
@@ -66,7 +66,7 @@ func New(obj interface{}, action string) Event {
 		kind = "replication controller"
 		reason = action
 		status = m[action]
-	} else if apiDeployment, ok := obj.(*v1beta1.Deployment); ok {
+	} else if apiDeployment, ok := obj.(*apps_v1beta1.Deployment); ok {
 		namespace = apiDeployment.ObjectMeta.Namespace
 		name = apiDeployment.Name
 		kind = "deployment"


### PR DESCRIPTION
This PR does the following:

- Point travis at the bitnami-labs endpoint instead of the previous skippbox endpoint
- Removes excessive code. Rather than having a controller function for each resource type, there's now a single resource controller. The informer is now created when checking the resource type (which was the only difference between the functions) and then the informer and resource type are now passed to the resourcecontroller function as parameters.
- Fixes an existing issue with the deployment resource type. Previously the deployment controller function was trying to return a service type (copy \ paste error on my part). This has been fixed and now allows deployment resources to be watched.
- Deployment resources now use the apps v1beta1 resource type. This fixes an error that was occurring in the slack handler, which essentially just sent out blank reports saying something happened, but didn't specify the resource type or where it was happening at.