### PR TITLE
Fix for #51: listen only to latest events.

### DIFF
--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -4,6 +4,10 @@ import (
 	"os"
 
 	"github.com/Sirupsen/logrus"
+	apps_v1 "k8s.io/api/apps/v1"
+	batch_v1 "k8s.io/api/batch/v1"
+	api_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -42,4 +46,32 @@ func GetClientOutOfCluster() kubernetes.Interface {
 	clientset, err := kubernetes.NewForConfig(config)
 
 	return clientset
+}
+
+// GetObjectMetaData returns metadata of a given k8s object
+func GetObjectMetaData(obj interface{}) meta_v1.ObjectMeta {
+
+	var objectMeta meta_v1.ObjectMeta
+
+	switch object := obj.(type) {
+	case *apps_v1.Deployment:
+		objectMeta = object.ObjectMeta
+	case *api_v1.ReplicationController:
+		objectMeta = object.ObjectMeta
+	case *apps_v1.ReplicaSet:
+		objectMeta = object.ObjectMeta
+	case *apps_v1.DaemonSet:
+		objectMeta = object.ObjectMeta
+	case *api_v1.Service:
+		objectMeta = object.ObjectMeta
+	case *api_v1.Pod:
+		objectMeta = object.ObjectMeta
+	case *batch_v1.Job:
+		objectMeta = object.ObjectMeta
+	case *api_v1.PersistentVolume:
+		objectMeta = object.ObjectMeta
+	case *api_v1.Namespace:
+		objectMeta = object.ObjectMeta
+	}
+	return objectMeta
 }


### PR DESCRIPTION
Hi, 

This PR, fixes issue reported in #51. 

kubewatch bombards the notification channel (say slack) with all the resources that were already present in the cluster. This is controlled by using `CreationTimestamp` properties available as part of object's metadata.