### PR TITLE
Add secrets and wehook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ resource:
       services: true
       pod: true
       secret: false
-      sealedsecret: false
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ resourcesToWatch:
   replicaset: false
   replicationcontroller: false
   services: true
+  secret: false
 slack:
   channel: '#YOUR_CHANNEL'
   token: 'xoxb-YOUR_TOKEN'
@@ -78,6 +79,8 @@ resource:
       daemonset: false
       services: true
       pod: true
+      secret: false
+      sealedsecret: false
 ```
 
 ## Building

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -37,4 +37,5 @@ func init() {
 	configCmd.AddCommand(mattermostConfigCmd)
 	configCmd.AddCommand(resourceConfigCmd)
 	configCmd.AddCommand(flockConfigCmd)
+	configCmd.AddCommand(webhookConfigCmd)
 }

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -97,6 +97,13 @@ var resourceConfigCmd = &cobra.Command{
 			logrus.Fatal("ds", err)
 		}
 
+		b, err = cmd.Flags().GetBool("secret")
+		if err == nil {
+			conf.Resource.Secret= b
+		} else {
+			logrus.Fatal("secret", err)
+		}
+
 		if err = conf.Write(); err != nil {
 			logrus.Fatal(err)
 		}
@@ -113,4 +120,5 @@ func init() {
 	resourceConfigCmd.Flags().Bool("pv", false, "watch for persistent volumes")
 	resourceConfigCmd.Flags().Bool("jobs", false, "watch for jobs")
 	resourceConfigCmd.Flags().Bool("ds", false, "watch for daemonsets")
+	resourceConfigCmd.Flags().Bool("secret", false, "watch for plain secrets")
 }

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 Skippbox, Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/bitnami-labs/kubewatch/config"
+	"github.com/Sirupsen/logrus"
+)
+
+// webhookConfigCmd represents the webhook subcommand
+var webhookConfigCmd = &cobra.Command{
+	Use:   "webhook FLAG",
+	Short: "specific webhook configuration",
+	Long: `specific webhook configuration`,
+	Run: func(cmd *cobra.Command, args []string){
+		conf, err := config.New()
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		url, err := cmd.Flags().GetString("url")
+		if err == nil {
+			if len(url) > 0 {
+				conf.Handler.Webhook.Url = url
+			}
+		} else {
+			logrus.Fatal(err)
+		}
+
+		if err = conf.Write(); err != nil {
+			logrus.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	webhookConfigCmd.Flags().StringP("url", "u", "", "Specify Webhook url")
+}

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Skippbox, Ltd.
+Copyright 2018 Bitnami
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-
 	"gopkg.in/yaml.v2"
 )
 
@@ -32,6 +31,7 @@ type Handler struct {
 	Hipchat Hipchat `json:"hipchat"`
 	Mattermost Mattermost `json:"mattermost"`
 	Flock Flock `json:"flock"`
+	Webhook Webhook `json:"webhook"`
 }
 
 // Resource contains resource configuration
@@ -45,6 +45,7 @@ type Resource struct {
 	Job                   bool `json:"job"`
 	PersistentVolume      bool `json:"pv"`
 	Namespace	      bool `json:"ns"`
+	Secret                bool `json:"secret"`
 }
 
 // Config struct contains kubewatch configuration
@@ -76,6 +77,11 @@ type Mattermost struct {
 
 // Flock contains flock configuration
 type Flock struct {
+	Url string `json:"url"`
+}
+
+// Webhook contains mattermost configuration
+type Webhook struct {
 	Url string `json:"url"`
 }
 
@@ -164,6 +170,9 @@ func (c *Config) CheckMissingResourceEnvvars() {
 	}
 	if (c.Handler.Slack.Token == "") && (os.Getenv("SLACK_TOKEN") != "") {
 		c.Handler.Slack.Token = os.Getenv("SLACK_TOKEN")
+	}
+	if !c.Resource.Secret && os.Getenv("KW_SECRET") == "true" {
+		c.Resource.Secret = true
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ type Flock struct {
 	Url string `json:"url"`
 }
 
-// Webhook contains mattermost configuration
+// Webhook contains webhook configuration
 type Webhook struct {
 	Url string `json:"url"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -165,14 +165,14 @@ func (c *Config) CheckMissingResourceEnvvars() {
 	if !c.Resource.PersistentVolume && os.Getenv("KW_PERSISTENT_VOLUME") == "true" {
 		c.Resource.PersistentVolume = true
 	}
+	if !c.Resource.Secret && os.Getenv("KW_SECRET") == "true" {
+		c.Resource.Secret = true
+	}
 	if (c.Handler.Slack.Channel == "") && (os.Getenv("SLACK_CHANNEL") != "") {
 		c.Handler.Slack.Channel = os.Getenv("SLACK_CHANNEL")
 	}
 	if (c.Handler.Slack.Token == "") && (os.Getenv("SLACK_TOKEN") != "") {
 		c.Handler.Slack.Token = os.Getenv("SLACK_TOKEN")
-	}
-	if !c.Resource.Secret && os.Getenv("KW_SECRET") == "true" {
-		c.Resource.Secret = true
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,9 +25,8 @@ import (
 var configStr = `
 {
     "handler": {
-        "slack": {
-            "channel": "slack_channel",
-            "token": "slack_token"
+        "webhook": {
+            "url": "http://localhost:8080"
         }
     },
     "reason": ["created", "deleted", "updated"],
@@ -38,6 +37,7 @@ var configStr = `
     	"daemonset": "false",
     	"services": "false",
     	"pod": "false",
+    	"secret": "true",
     },
 }
 `

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,10 @@ import (
 var configStr = `
 {
     "handler": {
+        "slack": {
+	  "channel": "slack_channel",
+	  "token": "slack_token"
+	},
         "webhook": {
             "url": "http://localhost:8080"
         }

--- a/examples/conf/kubewatch.conf.webhook.yaml
+++ b/examples/conf/kubewatch.conf.webhook.yaml
@@ -1,0 +1,27 @@
+handler:
+  slack:
+    token: ""
+    channel: ""
+  hipchat:
+    token: ""
+    room: ""
+    url: ""
+  mattermost:
+    channel: ""
+    url: ""
+    username: ""
+  flock:
+    url: ""
+  webhook:
+    url: "http://localhost:8080"
+resource:
+  deployment: false
+  replicationcontroller: false
+  replicaset: false
+  daemonset: false
+  services: false
+  pod: false
+  job: false
+  persistentvolume: false
+  namespace: true
+  secret: false

--- a/kubewatch-configmap.yaml
+++ b/kubewatch-configmap.yaml
@@ -15,3 +15,4 @@ data:
       daemonset: false
       services: true
       pod: true
+      secret: false

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/hipchat"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/mattermost"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/flock"
+	"github.com/bitnami-labs/kubewatch/pkg/handlers/webhook"
 )
 
 // Run runs the event loop processing with given handler
@@ -40,6 +41,8 @@ func Run(conf *config.Config) {
 		eventHandler = new(mattermost.Mattermost)
 	case len(conf.Handler.Flock.Url) > 0:
 		eventHandler = new(flock.Flock)
+	case len(conf.Handler.Webhook.Url) > 0:
+		eventHandler = new(webhook.Webhook)
 	default:
 		eventHandler = new(handlers.Default)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -253,6 +253,28 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 		go c.Run(stopCh)
 	}
 
+	if conf.Resource.Secret {
+		informer := cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+					return kubeClient.CoreV1().Secrets(meta_v1.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+					return kubeClient.CoreV1().Secrets(meta_v1.NamespaceAll).Watch(options)
+				},
+			},
+			&api_v1.Secret{},
+			0, //Skip resync
+			cache.Indexers{},
+		)
+
+		c := newResourceController(kubeClient, eventHandler, informer, "secret")
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+
+		go c.Run(stopCh)
+	}
+
 	sigterm := make(chan os.Signal, 1)
 	signal.Notify(sigterm, syscall.SIGTERM)
 	signal.Notify(sigterm, syscall.SIGINT)

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -98,6 +98,12 @@ func New(obj interface{}, action string) Event {
 		kind = "replica set"
 		reason = action
 		status = m[action]
+	} else if apiSecret , ok := obj.(*api_v1.Secret); ok {
+		namespace = apiSecret.ObjectMeta.Namespace
+		name = apiSecret.Name
+		kind = "secret"
+		reason = action
+		status = m[action]
 	}
 
 	kbEvent := Event{

--- a/pkg/handlers/handler.go
+++ b/pkg/handlers/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/hipchat"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/mattermost"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/flock"
+	"github.com/bitnami-labs/kubewatch/pkg/handlers/webhook"
 )
 
 // Handler is implemented by any handler.
@@ -40,6 +41,7 @@ var Map = map[string]interface{}{
 	"hipchat": &hipchat.Hipchat{},
 	"mattermost": &mattermost.Mattermost{},
 	"flock": &flock.Flock{},
+	"webhook": &webhook.Webhook{},
 }
 
 // Default handler implements Handler interface,

--- a/pkg/handlers/webhook/webhook.go
+++ b/pkg/handlers/webhook/webhook.go
@@ -45,11 +45,11 @@ Command line flags will override environment variables
 // Webhook handler implements handler.Handler interface,
 // Notify event to Webhook channel
 type Webhook struct {
-	Url      string
+	Url string
 }
 
 type WebhookMessage struct {
-	Text         string                         `json:"text"`
+	Text string `json:"text"`
 }
 
 // Init prepares Webhook configuration
@@ -88,7 +88,7 @@ func notifyWebhook(m *Webhook, obj interface{}, action string) {
 		return
 	}
 
-	log.Printf("Message successfully sent to %s at %s ", m.Url , time.Now())
+	log.Printf("Message successfully sent to %s at %s ", m.Url, time.Now())
 }
 
 func checkMissingWebhookVars(s *Webhook) error {
@@ -100,9 +100,9 @@ func checkMissingWebhookVars(s *Webhook) error {
 }
 
 func prepareWebhookMessage(e kbEvent.Event, m *Webhook) *WebhookMessage {
-      return &WebhookMessage{
-        e.Message(),
-        }
+	return &WebhookMessage{
+		e.Message(),
+	}
 
 }
 

--- a/pkg/handlers/webhook/webhook.go
+++ b/pkg/handlers/webhook/webhook.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Skippbox, Ltd.
+Copyright 2018 Bitnami
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/handlers/webhook/webhook.go
+++ b/pkg/handlers/webhook/webhook.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2016 Skippbox, Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/bitnami-labs/kubewatch/config"
+	kbEvent "github.com/bitnami-labs/kubewatch/pkg/event"
+)
+
+var webhookErrMsg = `
+%s
+
+You need to set Webhook url
+using "--url/-u" or using environment variables:
+
+export KW_WEBHOOK_URL=webhook_url
+
+Command line flags will override environment variables
+
+`
+
+// Webhook handler implements handler.Handler interface,
+// Notify event to Webhook channel
+type Webhook struct {
+	Url      string
+}
+
+type WebhookMessage struct {
+	Text         string                         `json:"text"`
+}
+
+// Init prepares Webhook configuration
+func (m *Webhook) Init(c *config.Config) error {
+	url := c.Handler.Webhook.Url
+
+	if url == "" {
+		url = os.Getenv("KW_WEBHOOK_URL")
+	}
+
+	m.Url = url
+
+	return checkMissingWebhookVars(m)
+}
+
+func (m *Webhook) ObjectCreated(obj interface{}) {
+	notifyWebhook(m, obj, "created")
+}
+
+func (m *Webhook) ObjectDeleted(obj interface{}) {
+	notifyWebhook(m, obj, "deleted")
+}
+
+func (m *Webhook) ObjectUpdated(oldObj, newObj interface{}) {
+	notifyWebhook(m, newObj, "updated")
+}
+
+func notifyWebhook(m *Webhook, obj interface{}, action string) {
+	e := kbEvent.New(obj, action)
+
+	webhookMessage := prepareWebhookMessage(e, m)
+
+	err := postMessage(m.Url, webhookMessage)
+	if err != nil {
+		log.Printf("%s\n", err)
+		return
+	}
+
+	log.Printf("Message successfully sent to %s at %s ", m.Url , time.Now())
+}
+
+func checkMissingWebhookVars(s *Webhook) error {
+	if s.Url == "" {
+		return fmt.Errorf(webhookErrMsg, "Missing Webhook url")
+	}
+
+	return nil
+}
+
+func prepareWebhookMessage(e kbEvent.Event, m *Webhook) *WebhookMessage {
+      return &WebhookMessage{
+        e.Message(),
+        }
+
+}
+
+func postMessage(url string, webhookMessage *WebhookMessage) error {
+	message, err := json.Marshal(webhookMessage)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(message))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	client := &http.Client{}
+	_, err = client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/handlers/webhook/webhook_test.go
+++ b/pkg/handlers/webhook/webhook_test.go
@@ -30,9 +30,9 @@ func TestWebhookInit(t *testing.T) {
 
 	var Tests = []struct {
 		webhook config.Webhook
-		err   error
+		err     error
 	}{
-		{config.Webhook{Url: "foo"}, nil },
+		{config.Webhook{Url: "foo"}, nil},
 		{config.Webhook{}, expectedError},
 	}
 

--- a/pkg/handlers/webhook/webhook_test.go
+++ b/pkg/handlers/webhook/webhook_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Skippbox, Ltd.
+Copyright 2018 Bitnami
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/handlers/webhook/webhook_test.go
+++ b/pkg/handlers/webhook/webhook_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2016 Skippbox, Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/bitnami-labs/kubewatch/config"
+)
+
+func TestWebhookInit(t *testing.T) {
+	s := &Webhook{}
+	expectedError := fmt.Errorf(webhookErrMsg, "Missing Webhook url")
+
+	var Tests = []struct {
+		webhook config.Webhook
+		err   error
+	}{
+		{config.Webhook{Url: "foo"}, nil },
+		{config.Webhook{}, expectedError},
+	}
+
+	for _, tt := range Tests {
+		c := &config.Config{}
+		c.Handler.Webhook = tt.webhook
+		if err := s.Init(c); !reflect.DeepEqual(err, tt.err) {
+			t.Fatalf("Init(): %v", err)
+		}
+	}
+}


### PR DESCRIPTION
In order to detect events described on https://github.com/bitnami-labs/sealed-secrets/issues/83, 
I needed to add support for Kubernetes secret object and simple support for a webhook handler. 

