### PR TITLE
Try to autodetect when is running in-cluster or running from outside 

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -56,7 +57,13 @@ type Controller struct {
 }
 
 func Start(conf *config.Config, eventHandler handlers.Handler) {
-	kubeClient := utils.GetClientOutOfCluster()
+	var kubeClient kubernetes.Interface
+	_, err := rest.InClusterConfig()
+	if err != nil {
+		kubeClient = utils.GetClientOutOfCluster()
+	} else {
+		kubeClient = utils.GetClient()
+	}
 	if conf.Resource.Pod {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -72,6 +72,8 @@ func GetObjectMetaData(obj interface{}) meta_v1.ObjectMeta {
 		objectMeta = object.ObjectMeta
 	case *api_v1.Namespace:
 		objectMeta = object.ObjectMeta
+	case *api_v1.Secret:
+		objectMeta = object.ObjectMeta
 	}
 	return objectMeta
 }


### PR DESCRIPTION
By this way, the same binary can be executed indistinctly without any previous knowledge of the environment where is running  