### PR TITLE
Add markdown formatting to event message

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -100,13 +100,13 @@ func (e *Event) Message() (msg string) {
 	switch e.Kind {
 	case "namespace":
 		msg = fmt.Sprintf(
-			"A namespace %s has been %s",
+			"A namespace `%s` has been `%s`",
 			e.Name,
 			e.Reason,
 		)
 	default:
 		msg = fmt.Sprintf(
-			"A %s in namespace %s has been %s: %s",
+			"A `%s` in namespace `%s` has been `%s`:\n`%s`",
 			e.Kind,
 			e.Namespace,
 			e.Reason,


### PR DESCRIPTION
This way the messages should look like this:

A `pod` in namespace `staging` has been `deleted`:
`default/hello-world-aafdf56d8bc-r49fq`