### PR TITLE
Use multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:alpine AS builder
 MAINTAINER "Cuong Manh Le <cuong.manhle.vn@gmail.com>"
 
 RUN apk update && \
@@ -11,5 +11,9 @@ ADD . "$GOPATH/src/github.com/bitnami-labs/kubewatch"
 RUN cd "$GOPATH/src/github.com/bitnami-labs/kubewatch" && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a --installsuffix cgo --ldflags="-s" -o /kubewatch
 
-COPY Dockerfile.run /
-CMD tar -cf - -C / Dockerfile.run kubewatch
+FROM alpine:3.4
+RUN apk add --update ca-certificates
+
+COPY --from=builder /kubewatch /bin/kubewatch
+
+ENTRYPOINT ["/bin/kubewatch"]

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,6 +1,0 @@
-FROM alpine:3.4
-RUN apk add --update ca-certificates
-
-COPY kubewatch /bin/kubewatch
-
-ENTRYPOINT ["/bin/kubewatch"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-.PHONY: default build builder-image binary-image test stop clean-images clean
+.PHONY: default build docker-image test stop clean-images clean
 
-BUILDER = kubewatch-builder
 BINARY = kubewatch
 
 VERSION=
@@ -15,11 +14,8 @@ default: build test
 build:
 	"$(GOCMD)" build ${GOFLAGS} ${LDFLAGS} -o "${BINARY}"
 
-builder-image:
-	@docker build -t "${BUILDER}" -f Dockerfile.build .
-
-binary-image: builder-image
-	@docker run --rm "${BUILDER}" | docker build -t "${BINARY}" -f Dockerfile.run -
+docker-image:
+	@docker build -t "${BINARY}" .
 
 test:
 	"$(GOCMD)" test -race -v $(shell go list ./... | grep -v '/vendor/')

--- a/README.md
+++ b/README.md
@@ -128,20 +128,11 @@ $ make build
 
 ### Building with Docker
 
-Buiding builder image:
-
 ```console
-$ make builder-image
-```
-
-Using the `kubewatch-builder` image to build `kubewatch` binary:
-
-```console
-$ make binary-image
+$ make docker-image
 $ docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
-kubewatch           latest              f1ade726c6e2        31 seconds ago       33.08 MB
-kubewatch-builder   latest              6b2d325a3b88        About a minute ago   514.2 MB
+kubewatch           latest              919896d3cd90        3 minutes ago       27.9MB
 ```
 
 ## Download kubewatch package


### PR DESCRIPTION
Use Docker's multi-stage builds to simplify the image building process.