### PR TITLE
Add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,18 @@ BINARY = kubewatch
 VERSION=
 BUILD=
 
-GOCMD = go
-GOFLAGS ?= $(GOFLAGS:)
-LDFLAGS =
+PKG            = github.com/bitnami-labs/kubewatch
+TRAVIS_COMMIT ?= `git rev-parse HEAD`
+GOCMD          = go
+BUILD_DATE     = `date`
+GOFLAGS       ?= $(GOFLAGS:)
+LDFLAGS       := "-X '$(PKG)/cmd.gitCommit=$(TRAVIS_COMMIT)' \
+		          -X '$(PKG)/cmd.buildDate=$(BUILD_DATE)'"
 
 default: build test
 
 build:
-	"$(GOCMD)" build ${GOFLAGS} ${LDFLAGS} -o "${BINARY}"
+	"$(GOCMD)" build ${GOFLAGS} -ldflags ${LDFLAGS} -o "${BINARY}"
 
 docker-image:
 	@docker build -t "${BINARY}" .

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2016 Skippbox, Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	buildDate, gitCommit string
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "print version",
+	Long:  `print version`,
+	Run: func(cmd *cobra.Command, args []string) {
+		versionPrettyString()
+	},
+}
+
+func versionPrettyString() {
+	logrus.Info("gitCommit: ", gitCommit)
+	logrus.Info("buildDate: ", buildDate)
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Hi,
To help with troubleshooting, example: https://github.com/bitnami-labs/kubewatch/issues/137 kubewatch could provide a version command that could be pointed out in order to give fetch details on the version being run, additional information such as semantic version from tags could be easily added later.

I think to start commit and date will be helpful, if this makes sense to you
```
$ make build && ./kubewatch version
"go" build  -ldflags "-X 'github.com/bitnami-labs/kubewatch/cmd.gitCommit=`git rev-parse HEAD`' -X 'github.com/bitnami-labs/kubewatch/cmd.buildDate=`date`'" -o "kubewatch"
INFO[0000] gitCommit: 5772afdd620a4b2bfe26f71e2dfb6d6a96b076cb 
INFO[0000] buildDate: Sat Sep 29 21:47:21 IST 2018
```
I was unable to test the environment variable`TRAVIS_COMMIT` within travis-ci itself but based in the documentation this should just be available to use https://docs.travis-ci.com/user/environment-variables/#default-environment-variables, building locally would rely on `git` to fetch the commit value.

Cheers 