### PR TITLE
Feature: "config test" subcommand fot testing Webhooks/Handlers. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Usage:
 
 Available Commands:
   add         add webhook config to .kubewatch.yaml
+  test        test handler config present in .kubewatch.yaml
   view        view .kubewatch.yaml
 
 Flags:
@@ -222,6 +223,30 @@ Use "kubewatch config [command] --help" for more information about a command.
   ```console
   $ export KW_FLOCK_URL='https://api.flock.com/hooks/sendMessage/XXXXXXXX'
   ```
+
+## Testing Config
+
+To test the handler config by send test messages use the following command.
+```
+$ kubewatch config test -h
+
+Tests handler configs present in .kubewatch.yaml by sending test messages
+
+Usage:
+  kubewatch config test [flags]
+
+Flags:
+  -h, --help   help for test
+```
+
+#### Example:
+
+```
+$ kubewatch config test
+
+Testing Handler configs from .kubewatch.yaml
+2019/06/03 12:29:23 Message successfully sent to channel ABCD at 1559545162.000100
+```
 
 ## Viewing config
 To view the entire config file `$HOME/.kubewatch.yaml` use the following command.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -18,9 +18,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/bitnami-labs/kubewatch/config"
+	"github.com/bitnami-labs/kubewatch/pkg/client"
+	"github.com/spf13/cobra"
 )
 
 // configCmd represents the config command
@@ -28,7 +32,7 @@ var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "modify kubewatch configuration",
 	Long: `
-config command allows admin setup his own configuration for running kubewatch`,
+config command allows configuration of .kubewatch.yaml for running kubewatch`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
@@ -44,11 +48,27 @@ Adds webhook config to .kubewatch.yaml`,
 	},
 }
 
+var configTestCmd = &cobra.Command{
+	Use:   "test",
+	Short: "test handler config present in .kubewatch.yaml",
+	Long: `
+Tests handler configs present in .kubewatch.yaml by sending test messages`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Testing Handler configs from .kubewatch.yaml")
+		conf, err := config.New()
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		eventHandler := client.ParseEventHandler(conf)
+		eventHandler.TestHandler()
+	},
+}
+
 var configViewCmd = &cobra.Command{
 	Use:   "view",
 	Short: "view .kubewatch.yaml",
 	Long: `
-display the contents of the contents of .kubewatch.yaml`,
+Display the contents of the contents of .kubewatch.yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Contents of .kubewatch.yaml")
 		configFile, err := ioutil.ReadFile(os.Getenv("HOME") + "/" + ".kubewatch.yaml")
@@ -62,9 +82,11 @@ display the contents of the contents of .kubewatch.yaml`,
 func init() {
 	RootCmd.AddCommand(configCmd)
 	configCmd.AddCommand(
-		configViewCmd,
 		configAddCmd,
+		configTestCmd,
+		configViewCmd,
 	)
+
 	configAddCmd.AddCommand(
 		slackConfigCmd,
 		hipchatConfigCmd,

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -32,6 +32,14 @@ import (
 
 // Run runs the event loop processing with given handler
 func Run(conf *config.Config) {
+
+	var eventHandler = ParseEventHandler(conf)
+	controller.Start(conf, eventHandler)
+}
+
+// ParseEventHandler returns the respective handler object specified in the config file.
+func ParseEventHandler(conf *config.Config) handlers.Handler {
+
 	var eventHandler handlers.Handler
 	switch {
 	case len(conf.Handler.Slack.Channel) > 0 || len(conf.Handler.Slack.Token) > 0:
@@ -49,9 +57,8 @@ func Run(conf *config.Config) {
 	default:
 		eventHandler = new(handlers.Default)
 	}
-
 	if err := eventHandler.Init(conf); err != nil {
 		log.Fatal(err)
 	}
-	controller.Start(conf, eventHandler)
+	return eventHandler
 }

--- a/pkg/handlers/flock/flock.go
+++ b/pkg/handlers/flock/flock.go
@@ -101,6 +101,28 @@ func (f *Flock) ObjectUpdated(oldObj, newObj interface{}) {
 	notifyFlock(f, newObj, "updated")
 }
 
+// TestHandler tests the handler configurarion by sending test messages.
+func (f *Flock) TestHandler() {
+
+	flockMessage := &FlockMessage{
+		Text:         "Kubewatch Alert",
+		Notification: "Kubewatch Alert",
+		Attachements: []FlockMessageAttachement{
+			{
+				Title: "Testing Handler Configuration. This is a Test message.",
+			},
+		},
+	}
+
+	err := postMessage(f.Url, flockMessage)
+	if err != nil {
+		log.Printf("%s\n", err)
+		return
+	}
+
+	log.Printf("Message successfully sent to channel %s at %s", f.Url, time.Now())
+}
+
 func notifyFlock(f *Flock, obj interface{}, action string) {
 	e := kbEvent.New(obj, action)
 

--- a/pkg/handlers/handler.go
+++ b/pkg/handlers/handler.go
@@ -33,6 +33,7 @@ type Handler interface {
 	ObjectCreated(obj interface{})
 	ObjectDeleted(obj interface{})
 	ObjectUpdated(oldObj, newObj interface{})
+	TestHandler()
 }
 
 // Map maps each event handler function to a name for easily lookup
@@ -69,5 +70,10 @@ func (d *Default) ObjectDeleted(obj interface{}) {
 
 // ObjectUpdated sends events on object updation
 func (d *Default) ObjectUpdated(oldObj, newObj interface{}) {
+
+}
+
+// TestHandler tests the handler configurarion by sending test messages.
+func (d *Default) TestHandler() {
 
 }

--- a/pkg/handlers/hipchat/hipchat.go
+++ b/pkg/handlers/hipchat/hipchat.go
@@ -98,6 +98,33 @@ func (s *Hipchat) ObjectUpdated(oldObj, newObj interface{}) {
 	notifyHipchat(s, newObj, "updated")
 }
 
+// TestHandler tests the handler configurarion by sending test messages.
+func (s *Hipchat) TestHandler() {
+
+	client := hipchat.NewClient(s.Token)
+	if s.Url != "" {
+		baseUrl, err := url.Parse(s.Url)
+		if err != nil {
+			panic(err)
+		}
+		client.BaseURL = baseUrl
+	}
+
+	notificationRequest := hipchat.NotificationRequest{
+		Message: "Testing Handler Configuration. This is a Test message.",
+		Notify:  true,
+		From:    "kubewatch",
+	}
+	_, err := client.Room.Notification(s.Room, &notificationRequest)
+
+	if err != nil {
+		log.Printf("%s\n", err)
+		return
+	}
+
+	log.Printf("Message successfully sent to room %s", s.Room)
+}
+
 func notifyHipchat(s *Hipchat, obj interface{}, action string) {
 	e := kbEvent.New(obj, action)
 

--- a/pkg/handlers/mattermost/mattermost.go
+++ b/pkg/handlers/mattermost/mattermost.go
@@ -113,6 +113,28 @@ func (m *Mattermost) ObjectUpdated(oldObj, newObj interface{}) {
 	notifyMattermost(m, newObj, "updated")
 }
 
+// TestHandler tests the handler configurarion by sending test messages.
+func (m *Mattermost) TestHandler() {
+	mattermostMessage := &MattermostMessage{
+		Channel:  m.Channel,
+		Username: m.Username,
+		IconUrl:  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo_with_border.png",
+		Attachements: []MattermostMessageAttachement{
+			{
+				Title: "Testing Handler Configuration. This is a Test message.",
+			},
+		},
+	}
+
+	err := postMessage(m.Url, mattermostMessage)
+	if err != nil {
+		log.Printf("%s\n", err)
+		return
+	}
+
+	log.Printf("Message successfully sent to channel %s at %s", m.Channel, time.Now())
+}
+
 func notifyMattermost(m *Mattermost, obj interface{}, action string) {
 	e := kbEvent.New(obj, action)
 

--- a/pkg/handlers/msteam/msteam.go
+++ b/pkg/handlers/msteam/msteam.go
@@ -167,3 +167,26 @@ func (ms *MSTeams) ObjectDeleted(obj interface{}) {
 func (ms *MSTeams) ObjectUpdated(oldObj, newObj interface{}) {
 	notifyMSTeams(ms, oldObj, "updated")
 }
+
+// TestHandler tests the handler configurarion by sending test messages.
+func (ms *MSTeams) TestHandler() {
+	card := &TeamsMessageCard{
+		Type:    messageType,
+		Context: context,
+		Title:   fmt.Sprintf("kubewatch"),
+		// Set a default Summary, this is required for Microsoft Teams
+		Summary: "kubewatch notification received",
+	}
+
+	var s TeamsMessageCardSection
+	s.ActivityTitle = "Testing Handler Configuration. This is a Test message."
+	s.Markdown = true
+	card.Sections = append(card.Sections, s)
+
+	if _, err := sendCard(ms, card); err != nil {
+		log.Printf("%s\n", err)
+		return
+	}
+
+	log.Printf("Message successfully sent to MS Teams")
+}

--- a/pkg/handlers/msteam/msteam_test.go
+++ b/pkg/handlers/msteam/msteam_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/bitnami-labs/kubewatch/config"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,7 +45,7 @@ func TestObjectCreated(t *testing.T) {
 		Title:      "kubewatch",
 		Text:       "",
 		Sections: []TeamsMessageCardSection{
-			TeamsMessageCardSection{
+			{
 				ActivityTitle: "A `pod` in namespace `new` has been `created`:\n`foo`",
 				Markdown:      true,
 			},
@@ -92,7 +92,7 @@ func TestObjectDeleted(t *testing.T) {
 		Title:      "kubewatch",
 		Text:       "",
 		Sections: []TeamsMessageCardSection{
-			TeamsMessageCardSection{
+			{
 				ActivityTitle: "A `pod` in namespace `new` has been `deleted`:\n`foo`",
 				Markdown:      true,
 			},
@@ -139,7 +139,7 @@ func TestObjectUpdated(t *testing.T) {
 		Title:      "kubewatch",
 		Text:       "",
 		Sections: []TeamsMessageCardSection{
-			TeamsMessageCardSection{
+			{
 				ActivityTitle: "A `pod` in namespace `new` has been `updated`:\n`foo`",
 				Markdown:      true,
 			},

--- a/pkg/handlers/slack/slack.go
+++ b/pkg/handlers/slack/slack.go
@@ -88,6 +88,29 @@ func (s *Slack) ObjectUpdated(oldObj, newObj interface{}) {
 	notifySlack(s, newObj, "updated")
 }
 
+// TestHandler tests the handler configurarion by sending test messages.
+func (s *Slack) TestHandler() {
+	api := slack.New(s.Token)
+	params := slack.PostMessageParameters{}
+	attachment := slack.Attachment{
+		Fields: []slack.AttachmentField{
+			{
+				Title: "kubewatch",
+				Value: "Testing Handler Configuration. This is a Test message.",
+			},
+		},
+	}
+	params.Attachments = []slack.Attachment{attachment}
+	params.AsUser = true
+	channelID, timestamp, err := api.PostMessage(s.Channel, "", params)
+	if err != nil {
+		log.Printf("%s\n", err)
+		return
+	}
+
+	log.Printf("Message successfully sent to channel %s at %s", channelID, timestamp)
+}
+
 func notifySlack(s *Slack, obj interface{}, action string) {
 	e := kbEvent.New(obj, action)
 	api := slack.New(s.Token)

--- a/pkg/handlers/webhook/webhook.go
+++ b/pkg/handlers/webhook/webhook.go
@@ -81,6 +81,22 @@ func (m *Webhook) ObjectUpdated(oldObj, newObj interface{}) {
 	notifyWebhook(m, newObj, "updated")
 }
 
+// TestHandler tests the handler configurarion by sending test messages.
+func (m *Webhook) TestHandler() {
+
+	webhookMessage := &WebhookMessage{
+		"Testing Handler Configuration. This is a Test message.",
+	}
+
+	err := postMessage(m.Url, webhookMessage)
+	if err != nil {
+		log.Printf("%s\n", err)
+		return
+	}
+
+	log.Printf("Message successfully sent to %s at %s ", m.Url, time.Now())
+}
+
 func notifyWebhook(m *Webhook, obj interface{}, action string) {
 	e := kbEvent.New(obj, action)
 


### PR DESCRIPTION
This commit 

- adds `config test` subcommand to send test messages to handlers(webhooks).
- lints code using `gofmt -w -s .` to lint code.
- Updates README.md regarding this new feature.

This feature eliminates the need for creating/deleteing dummy Kubernetes objects for testing the notification functionality of kubewatch. 

Now we could use the `kubewatch config test` to send test messages to the slack channel or the configured handler.

```
$ kubewatch config test
Testing Handler configs from .kubewatch.yaml
2019/06/03 13:21:23 Message successfully sent to channel GGF5T7H8F at 1559548283.000100
```
![test](https://user-images.githubusercontent.com/30741615/58785304-ef0a5880-8602-11e9-987c-aed0d8d64d69.png)


@tylerauerbeck  @jbianquetti-nami @jjo 
looking for comments and feedbacks :+1: 