### PR TITLE
Notify Cluster Level Critical Events and CrashLoopBackOff Events in pods

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ var RootCmd = &cobra.Command{
 	Use:   "kubewatch",
 	Short: "A watcher for Kubernetes",
 	Long: `
-Kubewath: A watcher for Kubernetes
+Kubewatch: A watcher for Kubernetes
 
 kubewatch is a Kubernetes watcher that could publishes notification
 to Slack/hipchat/mattermost/flock channels. It watches the cluster

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -127,6 +127,28 @@ func (e *Event) Message() (msg string) {
 			e.Name,
 			e.Reason,
 		)
+	case "NodeReady":
+		msg = fmt.Sprintf(
+			"Node `%s` is Ready : \nNodeReady",
+			e.Name,
+		)
+	case "NodeNotReady":
+		msg = fmt.Sprintf(
+			"Node `%s` is Not Ready : \nNodeNotReady",
+			e.Name,
+		)
+	case "NodeRebooted":
+		msg = fmt.Sprintf(
+			"Node `%s` Rebooted : \nNodeRebooted",
+			e.Name,
+		)
+	case "Backoff":
+		msg = fmt.Sprintf(
+			"Pod `%s` in `%s` Crashed : \nCrashLoopBackOff %s",
+			e.Name,
+			e.Namespace,
+			e.Reason,
+		)
 	default:
 		msg = fmt.Sprintf(
 			"A `%s` in namespace `%s` has been `%s`:\n`%s`",

--- a/pkg/handlers/flock/flock.go
+++ b/pkg/handlers/flock/flock.go
@@ -88,17 +88,17 @@ func (f *Flock) Init(c *config.Config) error {
 
 // ObjectCreated calls notifyFlock on event creation
 func (f *Flock) ObjectCreated(obj interface{}) {
-	notifyFlock(f, obj, "created")
+	notifyFlock(f, obj)
 }
 
 // ObjectDeleted calls notifyFlock on event creation
 func (f *Flock) ObjectDeleted(obj interface{}) {
-	notifyFlock(f, obj, "deleted")
+	notifyFlock(f, obj)
 }
 
 // ObjectUpdated calls notifyFlock on event creation
 func (f *Flock) ObjectUpdated(oldObj, newObj interface{}) {
-	notifyFlock(f, newObj, "updated")
+	notifyFlock(f, newObj)
 }
 
 // TestHandler tests the handler configurarion by sending test messages.
@@ -123,9 +123,9 @@ func (f *Flock) TestHandler() {
 	log.Printf("Message successfully sent to channel %s at %s", f.Url, time.Now())
 }
 
-func notifyFlock(f *Flock, obj interface{}, action string) {
-	e := kbEvent.New(obj, action)
-
+func notifyFlock(f *Flock, obj interface{}) {
+	e,_ := obj.(kbEvent.Event)
+	
 	flockMessage := prepareFlockMessage(e, f)
 
 	err := postMessage(f.Url, flockMessage)

--- a/pkg/handlers/hipchat/hipchat.go
+++ b/pkg/handlers/hipchat/hipchat.go
@@ -85,17 +85,17 @@ func (s *Hipchat) Init(c *config.Config) error {
 
 // ObjectCreated calls notifyHipchat on event creation
 func (s *Hipchat) ObjectCreated(obj interface{}) {
-	notifyHipchat(s, obj, "created")
+	notifyHipchat(s, obj)
 }
 
 // ObjectDeleted calls notifyHipchat on event creation
 func (s *Hipchat) ObjectDeleted(obj interface{}) {
-	notifyHipchat(s, obj, "deleted")
+	notifyHipchat(s, obj)
 }
 
 // ObjectUpdated calls notifyHipchat on event creation
 func (s *Hipchat) ObjectUpdated(oldObj, newObj interface{}) {
-	notifyHipchat(s, newObj, "updated")
+	notifyHipchat(s, newObj)
 }
 
 // TestHandler tests the handler configurarion by sending test messages.
@@ -125,8 +125,8 @@ func (s *Hipchat) TestHandler() {
 	log.Printf("Message successfully sent to room %s", s.Room)
 }
 
-func notifyHipchat(s *Hipchat, obj interface{}, action string) {
-	e := kbEvent.New(obj, action)
+func notifyHipchat(s *Hipchat, obj interface{}) {
+	e,_ := obj.(kbEvent.Event)
 
 	client := hipchat.NewClient(s.Token)
 	if s.Url != "" {

--- a/pkg/handlers/mattermost/mattermost.go
+++ b/pkg/handlers/mattermost/mattermost.go
@@ -100,17 +100,17 @@ func (m *Mattermost) Init(c *config.Config) error {
 
 // ObjectCreated calls notifyMattermost on event creation
 func (m *Mattermost) ObjectCreated(obj interface{}) {
-	notifyMattermost(m, obj, "created")
+	notifyMattermost(m, obj)
 }
 
 // ObjectDeleted calls notifyMattermost on event creation
 func (m *Mattermost) ObjectDeleted(obj interface{}) {
-	notifyMattermost(m, obj, "deleted")
+	notifyMattermost(m, obj)
 }
 
 // ObjectUpdated calls notifyMattermost on event creation
 func (m *Mattermost) ObjectUpdated(oldObj, newObj interface{}) {
-	notifyMattermost(m, newObj, "updated")
+	notifyMattermost(m, newObj)
 }
 
 // TestHandler tests the handler configurarion by sending test messages.
@@ -135,8 +135,8 @@ func (m *Mattermost) TestHandler() {
 	log.Printf("Message successfully sent to channel %s at %s", m.Channel, time.Now())
 }
 
-func notifyMattermost(m *Mattermost, obj interface{}, action string) {
-	e := kbEvent.New(obj, action)
+func notifyMattermost(m *Mattermost, obj interface{}) {
+	e,_ := obj.(kbEvent.Event)
 
 	mattermostMessage := prepareMattermostMessage(e, m)
 

--- a/pkg/handlers/msteam/msteam.go
+++ b/pkg/handlers/msteam/msteam.go
@@ -112,7 +112,7 @@ func sendCard(ms *MSTeams, card *TeamsMessageCard) (*http.Response, error) {
 }
 
 // notifyMSTeams creates the TeamsMessageCard and send to webhook URL
-func notifyMSTeams(ms *MSTeams, obj interface{}, action string) {
+func notifyMSTeams(ms *MSTeams, obj interface{}) {
 	card := &TeamsMessageCard{
 		Type:    messageType,
 		Context: context,
@@ -121,7 +121,7 @@ func notifyMSTeams(ms *MSTeams, obj interface{}, action string) {
 		Summary: "kubewatch notification received",
 	}
 
-	e := event.New(obj, action)
+	e,_ := obj.(event.Event)
 	card.ThemeColor = msTeamsColors[e.Status]
 
 	var s TeamsMessageCardSection
@@ -155,17 +155,17 @@ func (ms *MSTeams) Init(c *config.Config) error {
 
 // Notify on object creation
 func (ms *MSTeams) ObjectCreated(obj interface{}) {
-	notifyMSTeams(ms, obj, "created")
+	notifyMSTeams(ms, obj)
 }
 
 // Notify on object deletion
 func (ms *MSTeams) ObjectDeleted(obj interface{}) {
-	notifyMSTeams(ms, obj, "deleted")
+	notifyMSTeams(ms, obj)
 }
 
 // Notify on object update
 func (ms *MSTeams) ObjectUpdated(oldObj, newObj interface{}) {
-	notifyMSTeams(ms, oldObj, "updated")
+	notifyMSTeams(ms, oldObj)
 }
 
 // TestHandler tests the handler configurarion by sending test messages.

--- a/pkg/handlers/msteam/msteam_test.go
+++ b/pkg/handlers/msteam/msteam_test.go
@@ -9,8 +9,7 @@ import (
 	"testing"
 
 	"github.com/bitnami-labs/kubewatch/config"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/bitnami-labs/kubewatch/pkg/event"
 )
 
 // Tests the Init() function
@@ -46,7 +45,7 @@ func TestObjectCreated(t *testing.T) {
 		Text:       "",
 		Sections: []TeamsMessageCardSection{
 			{
-				ActivityTitle: "A `pod` in namespace `new` has been `created`:\n`foo`",
+				ActivityTitle: "A `pod` in namespace `new` has been `Created`:\n`foo`",
 				Markdown:      true,
 			},
 		},
@@ -68,17 +67,14 @@ func TestObjectCreated(t *testing.T) {
 	}))
 
 	ms := &MSTeams{TeamsWebhookURL: ts.URL}
-	p := &v1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			UID:       "12345678",
-			Name:      "foo",
-			Namespace: "new",
-		},
+	p := event.Event{
+		Name:      "foo",
+		Kind:      "pod",
+		Namespace: "new",
+		Reason:    "Created",
+		Status:    "Normal",
 	}
+
 	ms.ObjectCreated(p)
 }
 
@@ -93,7 +89,7 @@ func TestObjectDeleted(t *testing.T) {
 		Text:       "",
 		Sections: []TeamsMessageCardSection{
 			{
-				ActivityTitle: "A `pod` in namespace `new` has been `deleted`:\n`foo`",
+				ActivityTitle: "A `pod` in namespace `new` has been `Deleted`:\n`foo`",
 				Markdown:      true,
 			},
 		},
@@ -115,17 +111,15 @@ func TestObjectDeleted(t *testing.T) {
 	}))
 
 	ms := &MSTeams{TeamsWebhookURL: ts.URL}
-	p := &v1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			UID:       "12345678",
-			Name:      "foo",
-			Namespace: "new",
-		},
+
+	p := event.Event{
+		Name:      "foo",
+		Namespace: "new",
+		Kind:      "pod",
+		Reason:    "Deleted",
+		Status:    "Danger",
 	}
+
 	ms.ObjectDeleted(p)
 }
 
@@ -140,7 +134,7 @@ func TestObjectUpdated(t *testing.T) {
 		Text:       "",
 		Sections: []TeamsMessageCardSection{
 			{
-				ActivityTitle: "A `pod` in namespace `new` has been `updated`:\n`foo`",
+				ActivityTitle: "A `pod` in namespace `new` has been `Updated`:\n`foo`",
 				Markdown:      true,
 			},
 		},
@@ -163,28 +157,20 @@ func TestObjectUpdated(t *testing.T) {
 
 	ms := &MSTeams{TeamsWebhookURL: ts.URL}
 
-	oldP := &v1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			UID:       "12345678",
-			Name:      "foo",
-			Namespace: "new",
-		},
+	oldP := event.Event{
+		Name:      "foo",
+		Namespace: "new",
+		Kind:      "pod",
+		Reason:    "Updated",
+		Status:    "Warning",
 	}
 
-	newP := &v1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			UID:       "12345678",
-			Name:      "foo-new",
-			Namespace: "new",
-		},
+	newP := event.Event{
+		Name:      "foo-new",
+		Namespace: "new",
+		Kind:      "pod",
+		Reason:    "Updated",
+		Status:    "Warning",
 	}
 
 	ms.ObjectUpdated(oldP, newP)

--- a/pkg/handlers/slack/slack.go
+++ b/pkg/handlers/slack/slack.go
@@ -85,17 +85,17 @@ func (s *Slack) Init(c *config.Config) error {
 
 // ObjectCreated calls notifySlack on event creation
 func (s *Slack) ObjectCreated(obj interface{}) {
-	notifySlack(s, obj, "created")
+	notifySlack(s, obj)
 }
 
 // ObjectDeleted calls notifySlack on event creation
 func (s *Slack) ObjectDeleted(obj interface{}) {
-	notifySlack(s, obj, "deleted")
+	notifySlack(s, obj)
 }
 
 // ObjectUpdated calls notifySlack on event creation
 func (s *Slack) ObjectUpdated(oldObj, newObj interface{}) {
-	notifySlack(s, newObj, "updated")
+	notifySlack(s, newObj)
 }
 
 // TestHandler tests the handler configurarion by sending test messages.
@@ -120,8 +120,8 @@ func (s *Slack) TestHandler() {
 	log.Printf("Message successfully sent to channel %s at %s", channelID, timestamp)
 }
 
-func notifySlack(s *Slack, obj interface{}, action string) {
-	e := kbEvent.New(obj, action)
+func notifySlack(s *Slack, obj interface{}) {
+	e,_ := obj.(kbEvent.Event)
 	api := slack.New(s.Token)
 	attachment := prepareSlackAttachment(e, s)
 

--- a/pkg/handlers/webhook/webhook.go
+++ b/pkg/handlers/webhook/webhook.go
@@ -78,17 +78,17 @@ func (m *Webhook) Init(c *config.Config) error {
 
 // ObjectCreated calls notifyWebhook on event creation
 func (m *Webhook) ObjectCreated(obj interface{}) {
-	notifyWebhook(m, obj, "created")
+	notifyWebhook(m, obj)
 }
 
 // ObjectDeleted calls notifyWebhook on event creation
 func (m *Webhook) ObjectDeleted(obj interface{}) {
-	notifyWebhook(m, obj, "deleted")
+	notifyWebhook(m, obj)
 }
 
 // ObjectUpdated calls notifyWebhook on event creation
 func (m *Webhook) ObjectUpdated(oldObj, newObj interface{}) {
-	notifyWebhook(m, newObj, "updated")
+	notifyWebhook(m, newObj)
 }
 
 // TestHandler tests the handler configurarion by sending test messages.
@@ -114,8 +114,8 @@ func (m *Webhook) TestHandler() {
 	log.Printf("Message successfully sent to %s at %s ", m.Url, time.Now())
 }
 
-func notifyWebhook(m *Webhook, obj interface{}, action string) {
-	e := kbEvent.New(obj, action)
+func notifyWebhook(m *Webhook, obj interface{}) {
+	e, _ := obj.(kbEvent.Event)
 
 	webhookMessage := prepareWebhookMessage(e, m)
 

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -54,10 +54,8 @@ func GetClientOutOfCluster() kubernetes.Interface {
 }
 
 // GetObjectMetaData returns metadata of a given k8s object
-func GetObjectMetaData(obj interface{}) meta_v1.ObjectMeta {
-
-	var objectMeta meta_v1.ObjectMeta
-
+func GetObjectMetaData(obj interface{}) (objectMeta meta_v1.ObjectMeta) {
+	
 	switch object := obj.(type) {
 	case *apps_v1.Deployment:
 		objectMeta = object.ObjectMeta
@@ -86,6 +84,8 @@ func GetObjectMetaData(obj interface{}) meta_v1.ObjectMeta {
 	case *rbac_v1beta1.ClusterRole:
 		objectMeta = object.ObjectMeta
 	case *api_v1.ServiceAccount:
+		objectMeta = object.ObjectMeta
+	case *api_v1.Event:
 		objectMeta = object.ObjectMeta
 	}
 	return objectMeta


### PR DESCRIPTION
This PR addresses #129 and #106,
- alerts on CrashLoopBackOff events occurring in pods ( when pods are being watched )
- alerts on cluster level critical events like 
     - NodeNotReady
     - NodeReady
     - NodeRebooted (by default)
- removes New() func from event pkg to enhance simplicity
- removes action filed from notify function in all handlers to enhance simplicity 
- retrieves namespace value and name from event key, if empty.
- modified msteam_test.go suitably to test functionalities.
- minor bug fixes
- fixing typos

### Preview :

#### CrashLoopBacKOff when Pods are Being Watched
![crashloopbackoff](https://user-images.githubusercontent.com/30741615/59497917-01617d80-8eb2-11e9-8c69-2cbfd4c99bd3.png)

#### Cluster Level Critical Events (Configured by default)
![1](https://user-images.githubusercontent.com/30741615/59959649-47819700-94d9-11e9-98f6-4f0b5d25c864.png)
![2](https://user-images.githubusercontent.com/30741615/59959650-481a2d80-94d9-11e9-8684-539dcaec3d4f.png)
![3](https://user-images.githubusercontent.com/30741615/59959651-481a2d80-94d9-11e9-9dbb-3d55018d5cb0.png)


Thoughts and Comments..?