### PR TITLE
Remove outdated image from kubewatch.yaml

### DIFF
--- a/kubewatch.yaml
+++ b/kubewatch.yaml
@@ -11,13 +11,6 @@ spec:
     volumeMounts:
     - name: config-volume
       mountPath: /root
-  - image: gcr.io/skippbox/kubectl:v1.3.0
-    args:
-      - proxy
-      - "-p"
-      - "8080"
-    name: proxy
-    imagePullPolicy: Always
   restartPolicy: Always
   volumes:
   - name: config-volume


### PR DESCRIPTION
I was following the tutorial in the README today, and I realized that the gcr.io/skippbox/kubectl:v1.3.0 is no longer available on gcloud. This should be removed from the kubewatch.yaml file, as the configuration section still completes without it (slack still receives messages).

Cited in https://github.com/bitnami-labs/kubewatch/issues/135 and https://github.com/bitnami-labs/kubewatch/issues/143
