### PR TITLE
Replace Alpine by minideb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:alpine AS builder
+FROM golang AS builder
 MAINTAINER "Cuong Manh Le <cuong.manhle.vn@gmail.com>"
 
-RUN apk update && \
-    apk add git build-base && \
-    rm -rf /var/cache/apk/* && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential && \
+    apt-get clean && \
     mkdir -p "$GOPATH/src/github.com/bitnami-labs/kubewatch"
 
 ADD . "$GOPATH/src/github.com/bitnami-labs/kubewatch"
@@ -11,8 +11,8 @@ ADD . "$GOPATH/src/github.com/bitnami-labs/kubewatch"
 RUN cd "$GOPATH/src/github.com/bitnami-labs/kubewatch" && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a --installsuffix cgo --ldflags="-s" -o /kubewatch
 
-FROM alpine:3.4
-RUN apk add --update ca-certificates
+FROM bitnami/minideb:stretch
+RUN install_packages ca-certificates
 
 COPY --from=builder /kubewatch /bin/kubewatch
 


### PR DESCRIPTION
- Replace Alpine by minideb
- `git` already installed:
```
Step 3/9 : RUN apt-get update && apt-get install -y --no-install-recommends git build-essential
 ---> Running in 9843c12aff27
Ign:1 http://deb.debian.org/debian stretch InRelease
Get:2 http://security.debian.org/debian-security stretch/updates InRelease [93.6 kB]
Get:3 http://deb.debian.org/debian stretch-updates InRelease [90.3 kB]
Get:4 http://deb.debian.org/debian stretch Release [118 kB]
Get:5 http://deb.debian.org/debian stretch Release.gpg [2434 B]
Get:6 http://security.debian.org/debian-security stretch/updates/main amd64 Packages [499 kB]
Get:7 http://deb.debian.org/debian stretch-updates/main amd64 Packages [27.2 kB]
Get:8 http://deb.debian.org/debian stretch/main amd64 Packages [7082 kB]
Fetched 7912 kB in 1s (5143 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
git is already the newest version (1:2.11.0-3+deb9u4).
```