### PR TITLE
Update readme to point to new location of helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ $ kubewatch -h
 
 Kubewatch: A watcher for Kubernetes
 
-kubewatch is a Kubernetes watcher that could publishes notification 
-to Slack/hipchat/mattermost/flock channels. It watches the cluster 
+kubewatch is a Kubernetes watcher that could publishes notification
+to Slack/hipchat/mattermost/flock channels. It watches the cluster
 for resource changes and notifies them through webhooks.
 
 supported webhooks:
@@ -45,7 +45,7 @@ Use "kubewatch [command] --help" for more information about a command.
 When you have helm installed in your cluster, use the following setup:
 
 ```console
-helm install --name kubewatch stable/kubewatch --set='rbac.create=true,slack.channel=#YOUR_CHANNEL,slack.token=xoxb-YOUR_TOKEN,resourcesToWatch.pod=true,resourcesToWatch.daemonset=true'
+helm install --name kubewatch bitnami/kubewatch --set='rbac.create=true,slack.channel=#YOUR_CHANNEL,slack.token=xoxb-YOUR_TOKEN,resourcesToWatch.pod=true,resourcesToWatch.daemonset=true'
 ```
 
 You may also provide a values file instead:
@@ -70,7 +70,7 @@ slack:
 And use that:
 
 ```console
-$ helm upgrade --install kubewatch stable/kubewatch --values=values-file.yml
+$ helm upgrade --install kubewatch bitnami/kubewatch --values=values-file.yml
 ```
 
 #### Using kubectl:
@@ -145,13 +145,13 @@ $ kubectl create -f kubewatch.yaml
 # Download and install kubewatch
 $ go get -u github.com/bitnami-labs/kubewatch
 
-# Configure the notification channel 
+# Configure the notification channel
 $ kubewatch config add slack --channel <slack_channel> --token <slack_token>
 
 # Add resources to be watched
 $ kubewatch resource add --po --svc
-INFO[0000] resource svc configured                      
-INFO[0000] resource po configured 
+INFO[0000] resource svc configured
+INFO[0000] resource po configured
 
 # start kubewatch server
 $ kubewatch
@@ -374,7 +374,7 @@ $ git clone https://github.com/bitnami-labs/kubewatch.git
 $ cd kubewatch
 $ go build -o kubewatch main.go
 ```
-or 
+or
 
 You can also use the Makefile directly:
 


### PR DESCRIPTION
The stable helm repo has been deprecated; indeed if you go to https://github.com/helm/charts/tree/master/stable/kubewatch you'll see a deprecation warning pointing to bitnami/kubewatch.

In the meantime all the updates have gone to bitnami/kubewatch and thus users following this README
are installing the wrong thing.