### PR TITLE
Simplify make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docker-image:
 	@docker build -t "${BINARY}" .
 
 test:
-	"$(GOCMD)" test -race -v $(shell go list ./... | grep -v '/vendor/')
+	"$(GOCMD)" test -race -v ./...
 
 stop:
 	@docker stop "${BINARY}"


### PR DESCRIPTION
it's been a few releases of the Go toolchain that the vendor dir is excluded from the ./... pattern
and thus we can remove the kludge.