### PR TITLE
Simplify handler interface

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/bitnami-labs/kubewatch/config"
 	"github.com/bitnami-labs/kubewatch/pkg/client"
+	"github.com/bitnami-labs/kubewatch/pkg/event"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -63,7 +64,16 @@ Tests handler configs present in ~/.kubewatch.yaml by sending test messages`,
 			logrus.Fatal(err)
 		}
 		eventHandler := client.ParseEventHandler(conf)
-		eventHandler.TestHandler()
+		e := event.Event{
+			Namespace: "testNamespace",
+			Name:      "testResource",
+			Kind:      "testKind",
+			Component: "testComponent",
+			Host:      "testHost",
+			Reason:    "Tested",
+			Status:    "Normal",
+		}
+		eventHandler.Handle(e)
 	},
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
-	"strings"
 
 	"github.com/bitnami-labs/kubewatch/config"
 	"github.com/bitnami-labs/kubewatch/pkg/event"
@@ -147,8 +147,7 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 
 	go nodeRebootedController.Run(stopNodeRebootedCh)
 
-
-	// User Configured Events  
+	// User Configured Events
 	if conf.Resource.Pod {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
@@ -626,7 +625,7 @@ func (c *Controller) processItem(newEvent Event) error {
 	}
 	// get object's metedata
 	objectMeta := utils.GetObjectMetaData(obj)
-	
+
 	// hold status type for default critical alerts
 	var status string
 
@@ -656,13 +655,13 @@ func (c *Controller) processItem(newEvent Event) error {
 				status = "Normal"
 			}
 			kbEvent := event.Event{
-				Name: objectMeta.Name,
+				Name:      objectMeta.Name,
 				Namespace: newEvent.namespace,
-				Kind: newEvent.resourceType,
-				Status: status,
-				Reason: "Created",
+				Kind:      newEvent.resourceType,
+				Status:    status,
+				Reason:    "Created",
 			}
-			c.eventHandler.ObjectCreated(kbEvent)
+			c.eventHandler.Handle(kbEvent)
 			return nil
 		}
 	case "update":
@@ -676,23 +675,23 @@ func (c *Controller) processItem(newEvent Event) error {
 			status = "Warning"
 		}
 		kbEvent := event.Event{
-			Name: newEvent.key,
+			Name:      newEvent.key,
 			Namespace: newEvent.namespace,
-			Kind: newEvent.resourceType,
-			Status: status,
-			Reason: "Updated",
+			Kind:      newEvent.resourceType,
+			Status:    status,
+			Reason:    "Updated",
 		}
-		c.eventHandler.ObjectUpdated(obj, kbEvent)
+		c.eventHandler.Handle(kbEvent)
 		return nil
 	case "delete":
 		kbEvent := event.Event{
 			Name:      newEvent.key,
 			Namespace: newEvent.namespace,
 			Kind:      newEvent.resourceType,
-			Status: "Danger",
-			Reason: "Deleted",
+			Status:    "Danger",
+			Reason:    "Deleted",
 		}
-		c.eventHandler.ObjectDeleted(kbEvent)
+		c.eventHandler.Handle(kbEvent)
 		return nil
 	}
 	return nil

--- a/pkg/handlers/flock/flock.go
+++ b/pkg/handlers/flock/flock.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/bitnami-labs/kubewatch/config"
-	kbEvent "github.com/bitnami-labs/kubewatch/pkg/event"
+	"github.com/bitnami-labs/kubewatch/pkg/event"
 )
 
 var flockColors = map[string]string{
@@ -86,46 +86,8 @@ func (f *Flock) Init(c *config.Config) error {
 	return checkMissingFlockVars(f)
 }
 
-// ObjectCreated calls notifyFlock on event creation
-func (f *Flock) ObjectCreated(obj interface{}) {
-	notifyFlock(f, obj)
-}
-
-// ObjectDeleted calls notifyFlock on event creation
-func (f *Flock) ObjectDeleted(obj interface{}) {
-	notifyFlock(f, obj)
-}
-
-// ObjectUpdated calls notifyFlock on event creation
-func (f *Flock) ObjectUpdated(oldObj, newObj interface{}) {
-	notifyFlock(f, newObj)
-}
-
-// TestHandler tests the handler configurarion by sending test messages.
-func (f *Flock) TestHandler() {
-
-	flockMessage := &FlockMessage{
-		Text:         "Kubewatch Alert",
-		Notification: "Kubewatch Alert",
-		Attachements: []FlockMessageAttachement{
-			{
-				Title: "Testing Handler Configuration. This is a Test message.",
-			},
-		},
-	}
-
-	err := postMessage(f.Url, flockMessage)
-	if err != nil {
-		log.Printf("%s\n", err)
-		return
-	}
-
-	log.Printf("Message successfully sent to channel %s at %s", f.Url, time.Now())
-}
-
-func notifyFlock(f *Flock, obj interface{}) {
-	e,_ := obj.(kbEvent.Event)
-	
+// Handle handles an event.
+func (f *Flock) Handle(e event.Event) {
 	flockMessage := prepareFlockMessage(e, f)
 
 	err := postMessage(f.Url, flockMessage)
@@ -145,8 +107,7 @@ func checkMissingFlockVars(s *Flock) error {
 	return nil
 }
 
-func prepareFlockMessage(e kbEvent.Event, f *Flock) *FlockMessage {
-
+func prepareFlockMessage(e event.Event, f *Flock) *FlockMessage {
 	return &FlockMessage{
 		Text:         "Kubewatch Alert",
 		Notification: "Kubewatch Alert",

--- a/pkg/handlers/handler.go
+++ b/pkg/handlers/handler.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"github.com/bitnami-labs/kubewatch/config"
+	"github.com/bitnami-labs/kubewatch/pkg/event"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/flock"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/hipchat"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/mattermost"
@@ -31,10 +32,7 @@ import (
 // The Handle method is used to process event
 type Handler interface {
 	Init(c *config.Config) error
-	ObjectCreated(obj interface{})
-	ObjectDeleted(obj interface{})
-	ObjectUpdated(oldObj, newObj interface{})
-	TestHandler()
+	Handle(e event.Event)
 }
 
 // Map maps each event handler function to a name for easily lookup
@@ -60,22 +58,6 @@ func (d *Default) Init(c *config.Config) error {
 	return nil
 }
 
-// ObjectCreated sends events on object creation
-func (d *Default) ObjectCreated(obj interface{}) {
-
-}
-
-// ObjectDeleted sends events on object deletion
-func (d *Default) ObjectDeleted(obj interface{}) {
-
-}
-
-// ObjectUpdated sends events on object updation
-func (d *Default) ObjectUpdated(oldObj, newObj interface{}) {
-
-}
-
-// TestHandler tests the handler configurarion by sending test messages.
-func (d *Default) TestHandler() {
-
+// Handle handles an event.
+func (d *Default) Handle(e event.Event) {
 }

--- a/pkg/handlers/hipchat/hipchat.go
+++ b/pkg/handlers/hipchat/hipchat.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/bitnami-labs/kubewatch/config"
 	"github.com/bitnami-labs/kubewatch/pkg/event"
-	kbEvent "github.com/bitnami-labs/kubewatch/pkg/event"
 )
 
 var hipchatColors = map[string]hipchat.Color{
@@ -83,51 +82,8 @@ func (s *Hipchat) Init(c *config.Config) error {
 	return checkMissingHipchatVars(s)
 }
 
-// ObjectCreated calls notifyHipchat on event creation
-func (s *Hipchat) ObjectCreated(obj interface{}) {
-	notifyHipchat(s, obj)
-}
-
-// ObjectDeleted calls notifyHipchat on event creation
-func (s *Hipchat) ObjectDeleted(obj interface{}) {
-	notifyHipchat(s, obj)
-}
-
-// ObjectUpdated calls notifyHipchat on event creation
-func (s *Hipchat) ObjectUpdated(oldObj, newObj interface{}) {
-	notifyHipchat(s, newObj)
-}
-
-// TestHandler tests the handler configurarion by sending test messages.
-func (s *Hipchat) TestHandler() {
-
-	client := hipchat.NewClient(s.Token)
-	if s.Url != "" {
-		baseUrl, err := url.Parse(s.Url)
-		if err != nil {
-			panic(err)
-		}
-		client.BaseURL = baseUrl
-	}
-
-	notificationRequest := hipchat.NotificationRequest{
-		Message: "Testing Handler Configuration. This is a Test message.",
-		Notify:  true,
-		From:    "kubewatch",
-	}
-	_, err := client.Room.Notification(s.Room, &notificationRequest)
-
-	if err != nil {
-		log.Printf("%s\n", err)
-		return
-	}
-
-	log.Printf("Message successfully sent to room %s", s.Room)
-}
-
-func notifyHipchat(s *Hipchat, obj interface{}) {
-	e,_ := obj.(kbEvent.Event)
-
+// Handle handles the notification.
+func (s *Hipchat) Handle(e event.Event) {
 	client := hipchat.NewClient(s.Token)
 	if s.Url != "" {
 		baseUrl, err := url.Parse(s.Url)
@@ -157,7 +113,6 @@ func checkMissingHipchatVars(s *Hipchat) error {
 }
 
 func prepareHipchatNotification(e event.Event) hipchat.NotificationRequest {
-
 	notification := hipchat.NotificationRequest{
 		Message: e.Message(),
 		Notify:  true,

--- a/pkg/handlers/mattermost/mattermost.go
+++ b/pkg/handlers/mattermost/mattermost.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/bitnami-labs/kubewatch/config"
-	kbEvent "github.com/bitnami-labs/kubewatch/pkg/event"
+	"github.com/bitnami-labs/kubewatch/pkg/event"
 )
 
 var mattermostColors = map[string]string{
@@ -98,46 +98,8 @@ func (m *Mattermost) Init(c *config.Config) error {
 	return checkMissingMattermostVars(m)
 }
 
-// ObjectCreated calls notifyMattermost on event creation
-func (m *Mattermost) ObjectCreated(obj interface{}) {
-	notifyMattermost(m, obj)
-}
-
-// ObjectDeleted calls notifyMattermost on event creation
-func (m *Mattermost) ObjectDeleted(obj interface{}) {
-	notifyMattermost(m, obj)
-}
-
-// ObjectUpdated calls notifyMattermost on event creation
-func (m *Mattermost) ObjectUpdated(oldObj, newObj interface{}) {
-	notifyMattermost(m, newObj)
-}
-
-// TestHandler tests the handler configurarion by sending test messages.
-func (m *Mattermost) TestHandler() {
-	mattermostMessage := &MattermostMessage{
-		Channel:  m.Channel,
-		Username: m.Username,
-		IconUrl:  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo_with_border.png",
-		Attachements: []MattermostMessageAttachement{
-			{
-				Title: "Testing Handler Configuration. This is a Test message.",
-			},
-		},
-	}
-
-	err := postMessage(m.Url, mattermostMessage)
-	if err != nil {
-		log.Printf("%s\n", err)
-		return
-	}
-
-	log.Printf("Message successfully sent to channel %s at %s", m.Channel, time.Now())
-}
-
-func notifyMattermost(m *Mattermost, obj interface{}) {
-	e,_ := obj.(kbEvent.Event)
-
+// Handle handles an event.
+func (m *Mattermost) Handle(e event.Event) {
 	mattermostMessage := prepareMattermostMessage(e, m)
 
 	err := postMessage(m.Url, mattermostMessage)
@@ -157,8 +119,7 @@ func checkMissingMattermostVars(s *Mattermost) error {
 	return nil
 }
 
-func prepareMattermostMessage(e kbEvent.Event, m *Mattermost) *MattermostMessage {
-
+func prepareMattermostMessage(e event.Event, m *Mattermost) *MattermostMessage {
 	return &MattermostMessage{
 		Channel:  m.Channel,
 		Username: m.Username,

--- a/pkg/handlers/msteam/msteam_test.go
+++ b/pkg/handlers/msteam/msteam_test.go
@@ -75,7 +75,7 @@ func TestObjectCreated(t *testing.T) {
 		Status:    "Normal",
 	}
 
-	ms.ObjectCreated(p)
+	ms.Handle(p)
 }
 
 // Tests ObjectDeleted() by passing v1.Pod
@@ -120,7 +120,7 @@ func TestObjectDeleted(t *testing.T) {
 		Status:    "Danger",
 	}
 
-	ms.ObjectDeleted(p)
+	ms.Handle(p)
 }
 
 // Tests ObjectUpdated() by passing v1.Pod
@@ -172,6 +172,7 @@ func TestObjectUpdated(t *testing.T) {
 		Reason:    "Updated",
 		Status:    "Warning",
 	}
+	_ = newP
 
-	ms.ObjectUpdated(oldP, newP)
+	ms.Handle(oldP)
 }

--- a/pkg/handlers/slack/slack.go
+++ b/pkg/handlers/slack/slack.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/bitnami-labs/kubewatch/config"
 	"github.com/bitnami-labs/kubewatch/pkg/event"
-	kbEvent "github.com/bitnami-labs/kubewatch/pkg/event"
 )
 
 var slackColors = map[string]string{
@@ -52,7 +51,7 @@ Command line flags will override environment variables
 type Slack struct {
 	Token   string
 	Channel string
-	Title string
+	Title   string
 }
 
 // Init prepares slack configuration
@@ -83,45 +82,8 @@ func (s *Slack) Init(c *config.Config) error {
 	return checkMissingSlackVars(s)
 }
 
-// ObjectCreated calls notifySlack on event creation
-func (s *Slack) ObjectCreated(obj interface{}) {
-	notifySlack(s, obj)
-}
-
-// ObjectDeleted calls notifySlack on event creation
-func (s *Slack) ObjectDeleted(obj interface{}) {
-	notifySlack(s, obj)
-}
-
-// ObjectUpdated calls notifySlack on event creation
-func (s *Slack) ObjectUpdated(oldObj, newObj interface{}) {
-	notifySlack(s, newObj)
-}
-
-// TestHandler tests the handler configurarion by sending test messages.
-func (s *Slack) TestHandler() {
-	api := slack.New(s.Token)
-	attachment := slack.Attachment{
-		Fields: []slack.AttachmentField{
-			{
-				Title: "kubewatch",
-				Value: "Testing Handler Configuration. This is a Test message.",
-			},
-		},
-	}
-	channelID, timestamp, err := api.PostMessage(s.Channel,
-		slack.MsgOptionAttachments(attachment),
-		slack.MsgOptionAsUser(true))
-	if err != nil {
-		log.Printf("%s\n", err)
-		return
-	}
-
-	log.Printf("Message successfully sent to channel %s at %s", channelID, timestamp)
-}
-
-func notifySlack(s *Slack, obj interface{}) {
-	e,_ := obj.(kbEvent.Event)
+// Handle handles the notification.
+func (s *Slack) Handle(e event.Event) {
 	api := slack.New(s.Token)
 	attachment := prepareSlackAttachment(e, s)
 

--- a/pkg/handlers/smtp/smtp.go
+++ b/pkg/handlers/smtp/smtp.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/bitnami-labs/kubewatch/config"
-	kbEvent "github.com/bitnami-labs/kubewatch/pkg/event"
+	"github.com/bitnami-labs/kubewatch/pkg/event"
 	"github.com/sirupsen/logrus"
 )
 
@@ -70,38 +70,13 @@ func (s *SMTP) Init(c *config.Config) error {
 	return nil
 }
 
-// ObjectCreated calls notifyWebhook on event creation
-func (s *SMTP) ObjectCreated(obj interface{}) {
-	notify(s, obj, "created")
-}
-
-// ObjectDeleted calls notifyWebhook on event creation
-func (s *SMTP) ObjectDeleted(obj interface{}) {
-	notify(s, obj, "deleted")
-}
-
-// ObjectUpdated calls notifyWebhook on event creation
-func (s *SMTP) ObjectUpdated(oldObj, newObj interface{}) {
-	notify(s, newObj, "updated")
-}
-
-// TestHandler tests the handler configurarion by sending test messages.
-func (s *SMTP) TestHandler() {
-	send(s.cfg, "test")
-}
-
-func notify(s *SMTP, obj interface{}, action string) {
-	e := kbEvent.New(obj, action)
-	msg, err := formatEmail(e, action)
-	if err != nil {
-		logrus.Error(err)
-		return
-	}
-	send(s.cfg, msg)
+// Handle handles the notification.
+func (s *SMTP) Handle(e event.Event) {
+	send(s.cfg, e.Message())
 	log.Printf("Message successfully sent to %s at %s ", s.cfg.To, time.Now())
 }
 
-func formatEmail(e kbEvent.Event, action string) (string, error) {
+func formatEmail(e event.Event) (string, error) {
 	return e.Message(), nil
 }
 

--- a/pkg/handlers/webhook/webhook.go
+++ b/pkg/handlers/webhook/webhook.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/bitnami-labs/kubewatch/config"
-	kbEvent "github.com/bitnami-labs/kubewatch/pkg/event"
+	"github.com/bitnami-labs/kubewatch/pkg/event"
 )
 
 var webhookErrMsg = `
@@ -76,47 +76,8 @@ func (m *Webhook) Init(c *config.Config) error {
 	return checkMissingWebhookVars(m)
 }
 
-// ObjectCreated calls notifyWebhook on event creation
-func (m *Webhook) ObjectCreated(obj interface{}) {
-	notifyWebhook(m, obj)
-}
-
-// ObjectDeleted calls notifyWebhook on event creation
-func (m *Webhook) ObjectDeleted(obj interface{}) {
-	notifyWebhook(m, obj)
-}
-
-// ObjectUpdated calls notifyWebhook on event creation
-func (m *Webhook) ObjectUpdated(oldObj, newObj interface{}) {
-	notifyWebhook(m, newObj)
-}
-
-// TestHandler tests the handler configurarion by sending test messages.
-func (m *Webhook) TestHandler() {
-
-	webhookMessage := &WebhookMessage{
-		EventMeta: EventMeta{
-			Kind:      "object",
-			Name:      "Test",
-			Namespace: "default",
-			Reason:    "Tested",
-		},
-		Text: "Testing Handler Configuration. This is a Test message.",
-		Time: time.Now(),
-	}
-
-	err := postMessage(m.Url, webhookMessage)
-	if err != nil {
-		log.Printf("%s\n", err)
-		return
-	}
-
-	log.Printf("Message successfully sent to %s at %s ", m.Url, time.Now())
-}
-
-func notifyWebhook(m *Webhook, obj interface{}) {
-	e, _ := obj.(kbEvent.Event)
-
+// Handle handles an event.
+func (m *Webhook) Handle(e event.Event) {
 	webhookMessage := prepareWebhookMessage(e, m)
 
 	err := postMessage(m.Url, webhookMessage)
@@ -136,7 +97,7 @@ func checkMissingWebhookVars(s *Webhook) error {
 	return nil
 }
 
-func prepareWebhookMessage(e kbEvent.Event, m *Webhook) *WebhookMessage {
+func prepareWebhookMessage(e event.Event, m *Webhook) *WebhookMessage {
 	return &WebhookMessage{
 		EventMeta: EventMeta{
 			Kind:      e.Kind,


### PR DESCRIPTION
The `interface{}` arguments were incredibly confusing (what kind of object was that? an object, an event?)
Furthermore turns out that all the handler implementations funneled all events through a generic "notifyFoo"
function. The even itself contains the kind of action (Created, Updated etc) so it really doesn't make
sense to have N handler methods one for each kind.

Also, the notification config test is handled though the same codepath as sending an actual notification;
having to duplicate the code for test was error prone.