### PR TITLE
Multiple namespaces feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ resource:
   secret: false
   configmap: false
   ingress: false
-namespace: ""
+namespace: []
 
 ```
 
@@ -417,6 +417,12 @@ $ kubewatch resource add --rc --po --svc
 # rc, po and svc will be stopped from being watched
 $ kubewatch resource remove --rc --po --svc
 ```
+
+## Namespaces
+
+If a specific set of namespaces need to be applied to the filter, that can be done with the namepace configuration as shown in the [example config ](examples/conf/kubewatch.conf.multiple.namespaces.yaml).
+
+This functionality can be useful for clusters where one is not admin and is merely a tennant.
 
 # Build
 

--- a/config/config.go
+++ b/config/config.go
@@ -77,7 +77,7 @@ type Config struct {
 
 	// For watching specific namespace, leave it empty for watching all.
 	// this config is ignored when watching namespaces
-	Namespace string `json:"namespace,omitempty"`
+	Namespace []string `json:"namespace,omitempty"`
 }
 
 // Slack contains slack configuration

--- a/config/sample.go
+++ b/config/sample.go
@@ -71,7 +71,7 @@ resource:
   secret: false
   configmap: false
   ing: false
-# For watching specific namespace, leave it empty for watching all.
+# For watching specific array of namespaces, leave it empty for watching all.
 # this config is ignored when watching namespaces
-namespace: ""
+namespace: []
 `

--- a/examples/conf/kubewatch.conf.multiple.namespaces.yaml
+++ b/examples/conf/kubewatch.conf.multiple.namespaces.yaml
@@ -4,10 +4,13 @@ metadata:
   name: kubewatch
 data:
   .kubewatch.yaml: |
-    namespace: []
+    namespace:
+      - namespaceOne
+      - namespaceTwo
     handler:
-      msteams:
-        webhookurl: https://outlook.office.com/webhook/...
+      slack:
+        token: xxx
+        channel: xxx
     resource:
       namespace: false
       deployment: false

--- a/kubewatch-configmap.yaml
+++ b/kubewatch-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubewatch
 data:
   .kubewatch.yaml: |
-    namespace: ""
+    namespace: []
     handler:
       slack:
         token: <token>

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+	rbac_v1beta1 "k8s.io/api/rbac/v1beta1"
 	"os"
 	"os/signal"
 	"strings"
@@ -34,7 +35,6 @@ import (
 	batch_v1 "k8s.io/api/batch/v1"
 	api_v1 "k8s.io/api/core/v1"
 	ext_v1beta1 "k8s.io/api/extensions/v1beta1"
-	rbac_v1beta1 "k8s.io/api/rbac/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -67,219 +67,14 @@ type Controller struct {
 	eventHandler handlers.Handler
 }
 
-// Start prepares watchers and run their controllers, then waits for process termination signals
-func Start(conf *config.Config, eventHandler handlers.Handler) {
+// Cluster Events - Start prepares watchers and run their controllers, then waits for process termination signals
+func StartClusterScope(conf *config.Config, eventHandler handlers.Handler) {
 	var kubeClient kubernetes.Interface
 
 	if _, err := rest.InClusterConfig(); err != nil {
 		kubeClient = utils.GetClientOutOfCluster()
 	} else {
 		kubeClient = utils.GetClient()
-	}
-
-	// Adding Default Critical Alerts
-	// For Capturing Critical Event NodeNotReady in Nodes
-	nodeNotReadyInformer := cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				options.FieldSelector = "involvedObject.kind=Node,type=Normal,reason=NodeNotReady"
-				return kubeClient.CoreV1().Events(conf.Namespace).List(options)
-			},
-			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				options.FieldSelector = "involvedObject.kind=Node,type=Normal,reason=NodeNotReady"
-				return kubeClient.CoreV1().Events(conf.Namespace).Watch(options)
-			},
-		},
-		&api_v1.Event{},
-		0, //Skip resync
-		cache.Indexers{},
-	)
-
-	nodeNotReadyController := newResourceController(kubeClient, eventHandler, nodeNotReadyInformer, "NodeNotReady")
-	stopNodeNotReadyCh := make(chan struct{})
-	defer close(stopNodeNotReadyCh)
-
-	go nodeNotReadyController.Run(stopNodeNotReadyCh)
-
-	// For Capturing Critical Event NodeReady in Nodes
-	nodeReadyInformer := cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				options.FieldSelector = "involvedObject.kind=Node,type=Normal,reason=NodeReady"
-				return kubeClient.CoreV1().Events(conf.Namespace).List(options)
-			},
-			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				options.FieldSelector = "involvedObject.kind=Node,type=Normal,reason=NodeReady"
-				return kubeClient.CoreV1().Events(conf.Namespace).Watch(options)
-			},
-		},
-		&api_v1.Event{},
-		0, //Skip resync
-		cache.Indexers{},
-	)
-
-	nodeReadyController := newResourceController(kubeClient, eventHandler, nodeReadyInformer, "NodeReady")
-	stopNodeReadyCh := make(chan struct{})
-	defer close(stopNodeReadyCh)
-
-	go nodeReadyController.Run(stopNodeReadyCh)
-
-	// For Capturing Critical Event NodeRebooted in Nodes
-	nodeRebootedInformer := cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				options.FieldSelector = "involvedObject.kind=Node,type=Warning,reason=Rebooted"
-				return kubeClient.CoreV1().Events(conf.Namespace).List(options)
-			},
-			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				options.FieldSelector = "involvedObject.kind=Node,type=Warning,reason=Rebooted"
-				return kubeClient.CoreV1().Events(conf.Namespace).Watch(options)
-			},
-		},
-		&api_v1.Event{},
-		0, //Skip resync
-		cache.Indexers{},
-	)
-
-	nodeRebootedController := newResourceController(kubeClient, eventHandler, nodeRebootedInformer, "NodeRebooted")
-	stopNodeRebootedCh := make(chan struct{})
-	defer close(stopNodeRebootedCh)
-
-	go nodeRebootedController.Run(stopNodeRebootedCh)
-
-	// User Configured Events
-	if conf.Resource.Pod {
-		informer := cache.NewSharedIndexInformer(
-			&cache.ListWatch{
-				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.CoreV1().Pods(conf.Namespace).List(options)
-				},
-				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.CoreV1().Pods(conf.Namespace).Watch(options)
-				},
-			},
-			&api_v1.Pod{},
-			0, //Skip resync
-			cache.Indexers{},
-		)
-
-		c := newResourceController(kubeClient, eventHandler, informer, "pod")
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-
-		go c.Run(stopCh)
-
-		// For Capturing CrashLoopBackOff Events in pods
-		backoffInformer := cache.NewSharedIndexInformer(
-			&cache.ListWatch{
-				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					options.FieldSelector = "involvedObject.kind=Pod,type=Warning,reason=BackOff"
-					return kubeClient.CoreV1().Events(conf.Namespace).List(options)
-				},
-				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					options.FieldSelector = "involvedObject.kind=Pod,type=Warning,reason=BackOff"
-					return kubeClient.CoreV1().Events(conf.Namespace).Watch(options)
-				},
-			},
-			&api_v1.Event{},
-			0, //Skip resync
-			cache.Indexers{},
-		)
-
-		backoffcontroller := newResourceController(kubeClient, eventHandler, backoffInformer, "Backoff")
-		stopBackoffCh := make(chan struct{})
-		defer close(stopBackoffCh)
-
-		go backoffcontroller.Run(stopBackoffCh)
-
-	}
-
-	if conf.Resource.DaemonSet {
-		informer := cache.NewSharedIndexInformer(
-			&cache.ListWatch{
-				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.AppsV1().DaemonSets(conf.Namespace).List(options)
-				},
-				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.AppsV1().DaemonSets(conf.Namespace).Watch(options)
-				},
-			},
-			&apps_v1.DaemonSet{},
-			0, //Skip resync
-			cache.Indexers{},
-		)
-
-		c := newResourceController(kubeClient, eventHandler, informer, "daemon set")
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-
-		go c.Run(stopCh)
-	}
-
-	if conf.Resource.ReplicaSet {
-		informer := cache.NewSharedIndexInformer(
-			&cache.ListWatch{
-				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.AppsV1().ReplicaSets(conf.Namespace).List(options)
-				},
-				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.AppsV1().ReplicaSets(conf.Namespace).Watch(options)
-				},
-			},
-			&apps_v1.ReplicaSet{},
-			0, //Skip resync
-			cache.Indexers{},
-		)
-
-		c := newResourceController(kubeClient, eventHandler, informer, "replica set")
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-
-		go c.Run(stopCh)
-	}
-
-	if conf.Resource.Services {
-		informer := cache.NewSharedIndexInformer(
-			&cache.ListWatch{
-				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.CoreV1().Services(conf.Namespace).List(options)
-				},
-				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.CoreV1().Services(conf.Namespace).Watch(options)
-				},
-			},
-			&api_v1.Service{},
-			0, //Skip resync
-			cache.Indexers{},
-		)
-
-		c := newResourceController(kubeClient, eventHandler, informer, "service")
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-
-		go c.Run(stopCh)
-	}
-
-	if conf.Resource.Deployment {
-		informer := cache.NewSharedIndexInformer(
-			&cache.ListWatch{
-				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.AppsV1().Deployments(conf.Namespace).List(options)
-				},
-				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.AppsV1().Deployments(conf.Namespace).Watch(options)
-				},
-			},
-			&apps_v1.Deployment{},
-			0, //Skip resync
-			cache.Indexers{},
-		)
-
-		c := newResourceController(kubeClient, eventHandler, informer, "deployment")
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-
-		go c.Run(stopCh)
 	}
 
 	if conf.Resource.Namespace {
@@ -298,50 +93,6 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 		)
 
 		c := newResourceController(kubeClient, eventHandler, informer, "namespace")
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-
-		go c.Run(stopCh)
-	}
-
-	if conf.Resource.ReplicationController {
-		informer := cache.NewSharedIndexInformer(
-			&cache.ListWatch{
-				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.CoreV1().ReplicationControllers(conf.Namespace).List(options)
-				},
-				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.CoreV1().ReplicationControllers(conf.Namespace).Watch(options)
-				},
-			},
-			&api_v1.ReplicationController{},
-			0, //Skip resync
-			cache.Indexers{},
-		)
-
-		c := newResourceController(kubeClient, eventHandler, informer, "replication controller")
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-
-		go c.Run(stopCh)
-	}
-
-	if conf.Resource.Job {
-		informer := cache.NewSharedIndexInformer(
-			&cache.ListWatch{
-				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.BatchV1().Jobs(conf.Namespace).List(options)
-				},
-				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.BatchV1().Jobs(conf.Namespace).Watch(options)
-				},
-			},
-			&batch_v1.Job{},
-			0, //Skip resync
-			cache.Indexers{},
-		)
-
-		c := newResourceController(kubeClient, eventHandler, informer, "job")
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
@@ -370,22 +121,104 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.ServiceAccount {
+	if conf.Resource.ClusterRole {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.CoreV1().ServiceAccounts(conf.Namespace).List(options)
+					return kubeClient.RbacV1beta1().ClusterRoles().List(options)
 				},
 				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.CoreV1().ServiceAccounts(conf.Namespace).Watch(options)
+					return kubeClient.RbacV1beta1().ClusterRoles().Watch(options)
 				},
 			},
-			&api_v1.ServiceAccount{},
+			&rbac_v1beta1.ClusterRole{},
 			0, //Skip resync
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "service account")
+		c := newResourceController(kubeClient, eventHandler, informer, "cluster role")
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+
+		go c.Run(stopCh)
+	}
+
+	if conf.Resource.PersistentVolume {
+		informer := cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+					return kubeClient.CoreV1().PersistentVolumes().List(options)
+				},
+				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+					return kubeClient.CoreV1().PersistentVolumes().Watch(options)
+				},
+			},
+			&api_v1.PersistentVolume{},
+			0, //Skip resync
+			cache.Indexers{},
+		)
+
+		c := newResourceController(kubeClient, eventHandler, informer, "persistent volume")
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+
+		go c.Run(stopCh)
+	}
+	sigterm := make(chan os.Signal, 1)
+	signal.Notify(sigterm, syscall.SIGTERM)
+	signal.Notify(sigterm, syscall.SIGINT)
+	<-sigterm
+
+}
+
+// Namespace Specific Events - Start prepares watchers and run their controllers, then waits for process termination signals
+func StartNamespaceScope(conf *config.Config, eventHandler handlers.Handler, ns string) {
+	var kubeClient kubernetes.Interface
+
+	if _, err := rest.InClusterConfig(); err != nil {
+		kubeClient = utils.GetClientOutOfCluster()
+	} else {
+		kubeClient = utils.GetClient()
+	}
+
+	if conf.Resource.Namespace {
+		informer := cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+					return kubeClient.CoreV1().Namespaces().List(options)
+				},
+				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+					return kubeClient.CoreV1().Namespaces().Watch(options)
+				},
+			},
+			&api_v1.Namespace{},
+			0, //Skip resync
+			cache.Indexers{},
+		)
+
+		c := newResourceController(kubeClient, eventHandler, informer, "namespace")
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+
+		go c.Run(stopCh)
+	}
+
+	if conf.Resource.Node {
+		informer := cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+					return kubeClient.CoreV1().Nodes().List(options)
+				},
+				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+					return kubeClient.CoreV1().Nodes().Watch(options)
+				},
+			},
+			&api_v1.Node{},
+			0, //Skip resync
+			cache.Indexers{},
+		)
+
+		c := newResourceController(kubeClient, eventHandler, informer, "node")
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
@@ -436,76 +269,351 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.Secret {
-		informer := cache.NewSharedIndexInformer(
+
+		fmt.Println("Watcher added for namespace " + ns)
+		// Adding Default Critical Alerts
+		// For Capturing Critical Event NodeNotReady in Nodes
+		nodeNotReadyInformer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.CoreV1().Secrets(conf.Namespace).List(options)
+					options.FieldSelector = "involvedObject.kind=Node,type=Normal,reason=NodeNotReady"
+					return kubeClient.CoreV1().Events(ns).List(options)
 				},
 				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.CoreV1().Secrets(conf.Namespace).Watch(options)
+					options.FieldSelector = "involvedObject.kind=Node,type=Normal,reason=NodeNotReady"
+					return kubeClient.CoreV1().Events(ns).Watch(options)
 				},
 			},
-			&api_v1.Secret{},
+			&api_v1.Event{},
 			0, //Skip resync
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "secret")
-		stopCh := make(chan struct{})
-		defer close(stopCh)
+		nodeNotReadyController := newResourceController(kubeClient, eventHandler, nodeNotReadyInformer, "NodeNotReady")
+		stopNodeNotReadyCh := make(chan struct{})
+		defer close(stopNodeNotReadyCh)
 
-		go c.Run(stopCh)
-	}
+		go nodeNotReadyController.Run(stopNodeNotReadyCh)
 
-	if conf.Resource.ConfigMap {
-		informer := cache.NewSharedIndexInformer(
+		// For Capturing Critical Event NodeReady in Nodes
+		nodeReadyInformer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.CoreV1().ConfigMaps(conf.Namespace).List(options)
+					options.FieldSelector = "involvedObject.kind=Node,type=Normal,reason=NodeReady"
+					return kubeClient.CoreV1().Events(ns).List(options)
 				},
 				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.CoreV1().ConfigMaps(conf.Namespace).Watch(options)
+					options.FieldSelector = "involvedObject.kind=Node,type=Normal,reason=NodeReady"
+					return kubeClient.CoreV1().Events(ns).Watch(options)
 				},
 			},
-			&api_v1.ConfigMap{},
+			&api_v1.Event{},
 			0, //Skip resync
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "configmap")
-		stopCh := make(chan struct{})
-		defer close(stopCh)
+		nodeReadyController := newResourceController(kubeClient, eventHandler, nodeReadyInformer, "NodeReady")
+		stopNodeReadyCh := make(chan struct{})
+		defer close(stopNodeReadyCh)
 
-		go c.Run(stopCh)
-	}
+		go nodeReadyController.Run(stopNodeReadyCh)
 
-	if conf.Resource.Ingress {
-		informer := cache.NewSharedIndexInformer(
+		// For Capturing Critical Event NodeRebooted in Nodes
+		nodeRebootedInformer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-					return kubeClient.ExtensionsV1beta1().Ingresses(conf.Namespace).List(options)
+					options.FieldSelector = "involvedObject.kind=Node,type=Warning,reason=Rebooted"
+					return kubeClient.CoreV1().Events(ns).List(options)
 				},
 				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-					return kubeClient.ExtensionsV1beta1().Ingresses(conf.Namespace).Watch(options)
+					options.FieldSelector = "involvedObject.kind=Node,type=Warning,reason=Rebooted"
+					return kubeClient.CoreV1().Events(ns).Watch(options)
 				},
 			},
-			&ext_v1beta1.Ingress{},
+			&api_v1.Event{},
 			0, //Skip resync
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "ingress")
-		stopCh := make(chan struct{})
-		defer close(stopCh)
+		nodeRebootedController := newResourceController(kubeClient, eventHandler, nodeRebootedInformer, "NodeRebooted")
+		stopNodeRebootedCh := make(chan struct{})
+		defer close(stopNodeRebootedCh)
 
-		go c.Run(stopCh)
-	}
+		go nodeRebootedController.Run(stopNodeRebootedCh)
 
-	sigterm := make(chan os.Signal, 1)
-	signal.Notify(sigterm, syscall.SIGTERM)
-	signal.Notify(sigterm, syscall.SIGINT)
-	<-sigterm
+		// User Configured Events
+		if conf.Resource.Pod {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.CoreV1().Pods(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.CoreV1().Pods(ns).Watch(options)
+					},
+				},
+				&api_v1.Pod{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "pod")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+
+			// For Capturing CrashLoopBackOff Events in pods
+			backoffInformer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						options.FieldSelector = "involvedObject.kind=Pod,type=Warning,reason=BackOff"
+						return kubeClient.CoreV1().Events(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						options.FieldSelector = "involvedObject.kind=Pod,type=Warning,reason=BackOff"
+						return kubeClient.CoreV1().Events(ns).Watch(options)
+					},
+				},
+				&api_v1.Event{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			backoffcontroller := newResourceController(kubeClient, eventHandler, backoffInformer, "Backoff")
+			stopBackoffCh := make(chan struct{})
+			defer close(stopBackoffCh)
+
+			go backoffcontroller.Run(stopBackoffCh)
+
+		}
+
+		if conf.Resource.DaemonSet {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.AppsV1().DaemonSets(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.AppsV1().DaemonSets(ns).Watch(options)
+					},
+				},
+				&apps_v1.DaemonSet{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "daemon set")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+		}
+
+		if conf.Resource.ReplicaSet {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.AppsV1().ReplicaSets(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.AppsV1().ReplicaSets(ns).Watch(options)
+					},
+				},
+				&apps_v1.ReplicaSet{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "replica set")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+		}
+
+		if conf.Resource.Services {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.CoreV1().Services(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.CoreV1().Services(ns).Watch(options)
+					},
+				},
+				&api_v1.Service{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "service")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+		}
+
+		if conf.Resource.Deployment {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.AppsV1().Deployments(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.AppsV1().Deployments(ns).Watch(options)
+					},
+				},
+				&apps_v1.Deployment{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "deployment")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+		}
+
+
+		if conf.Resource.ReplicationController {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.CoreV1().ReplicationControllers(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.CoreV1().ReplicationControllers(ns).Watch(options)
+					},
+				},
+				&api_v1.ReplicationController{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "replication controller")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+		}
+
+		if conf.Resource.Job {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.BatchV1().Jobs(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.BatchV1().Jobs(ns).Watch(options)
+					},
+				},
+				&batch_v1.Job{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "job")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+		}
+
+		if conf.Resource.ServiceAccount {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.CoreV1().ServiceAccounts(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.CoreV1().ServiceAccounts(ns).Watch(options)
+					},
+				},
+				&api_v1.ServiceAccount{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "service account")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+		}
+
+		if conf.Resource.Secret {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.CoreV1().Secrets(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.CoreV1().Secrets(ns).Watch(options)
+					},
+				},
+				&api_v1.Secret{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "secret")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+		}
+
+		if conf.Resource.ConfigMap {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.CoreV1().ConfigMaps(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.CoreV1().ConfigMaps(ns).Watch(options)
+					},
+				},
+				&api_v1.ConfigMap{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "configmap")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+		}
+
+		if conf.Resource.Ingress {
+			informer := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+						return kubeClient.ExtensionsV1beta1().Ingresses(ns).List(options)
+					},
+					WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+						return kubeClient.ExtensionsV1beta1().Ingresses(ns).Watch(options)
+					},
+				},
+				&ext_v1beta1.Ingress{},
+				0, //Skip resync
+				cache.Indexers{},
+			)
+
+			c := newResourceController(kubeClient, eventHandler, informer, "ingress")
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go c.Run(stopCh)
+		}
+
+		sigterm := make(chan os.Signal, 1)
+		signal.Notify(sigterm, syscall.SIGTERM)
+		signal.Notify(sigterm, syscall.SIGINT)
+		<-sigterm
+
 }
 
 func newResourceController(client kubernetes.Interface, eventHandler handlers.Handler, informer cache.SharedIndexInformer, resourceType string) *Controller {


### PR DESCRIPTION
This pull request contains a working version of multiple namespaces selection.

I've tried the code changes from [PR 152](https://github.com/bitnami-labs/kubewatch/pull/152). However this code resulted in multiple notifications for the same event and issues with inconsistency while adding several namespaces watchers.
Here we create a thread per namespace when appropriate.

This feature is particularly helpful when you want to monitor a namespace of a cluster you are not admin as kubewatch allows that.

Note I am neither well versed on go nor spent a major amount of time on this. If the implementation sucks feel free to throw away. However the features have been working well in Openshift and AKS environments I use on and enterprise setting and may be useful for others. 
