### PR TITLE
Add support for signing webhooks with SHA256

### DIFF
--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -55,10 +55,11 @@ var webhookConfigCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 		if hmacSignatureHeader != "" {
-			if conf.Handler.Webhook.HMACKey == "" {
-				logrus.Warn("HMAC signature header is set but HMAC key is empty")
-			}
 			conf.Handler.Webhook.HMACSignatureHeader = hmacSignatureHeader
+		}
+
+		if conf.Handler.Webhook.HMACSignatureHeader != "" && conf.Handler.Webhook.HMACKey == "" {
+			logrus.Warn("HMAC signature header is set but HMAC key is empty")
 		}
 
 		if err = conf.Write(); err != nil {

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -42,6 +42,25 @@ var webhookConfigCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		hmacKey, err := cmd.Flags().GetString("hmac-key")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if hmacKey != "" {
+			conf.Handler.Webhook.HMACKey = hmacKey
+		}
+
+		hmacSignatureHeader, err := cmd.Flags().GetString("hmac-signature-header")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if hmacSignatureHeader != "" {
+			if conf.Handler.Webhook.HMACKey == "" {
+				logrus.Warn("HMAC signature header is set but HMAC key is empty")
+			}
+			conf.Handler.Webhook.HMACSignatureHeader = hmacSignatureHeader
+		}
+
 		if err = conf.Write(); err != nil {
 			logrus.Fatal(err)
 		}
@@ -50,4 +69,6 @@ var webhookConfigCmd = &cobra.Command{
 
 func init() {
 	webhookConfigCmd.Flags().StringP("url", "u", "", "Specify Webhook url")
+	webhookConfigCmd.Flags().String("hmac-key", "", "A base64 encoded string to generate a webhook signature with")
+	webhookConfigCmd.Flags().String("hmac-signature-header", "", "The name of the header to set the hmac signature value to")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -117,6 +117,12 @@ type Flock struct {
 type Webhook struct {
 	// Webhook URL.
 	Url string `json:"url"`
+	// HMACKey is a base64 encoded string to sign the webhook payload with
+	HMACKey string `json:"hmac_secret"`
+	// HMACSignatureHeader is the name of the http header to put the HMAC signature in.
+	// Defaults to "X-KubeWatch-Signature". The header value will be a hex encoded string of an
+	// HMAC signature using sha256.
+	HMACSignatureHeader string `json:"hmac_signature_header"`
 }
 
 // MSTeams contains MSTeams configuration

--- a/pkg/handlers/webhook/webhook_test.go
+++ b/pkg/handlers/webhook/webhook_test.go
@@ -17,11 +17,18 @@ limitations under the License.
 package webhook
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
 	"github.com/bitnami-labs/kubewatch/config"
+	"github.com/bitnami-labs/kubewatch/pkg/event"
 )
 
 func TestWebhookInit(t *testing.T) {
@@ -43,4 +50,99 @@ func TestWebhookInit(t *testing.T) {
 			t.Fatalf("Init(): %v", err)
 		}
 	}
+}
+
+func checkHeaderAndHMAC(hmacKey []byte, headerName string, r *http.Request) (headerOk, hmacSigOk bool) {
+	headerOk = r.Header.Get(headerName) != ""
+	hmacValue := r.Header.Get(headerName)
+
+	if hmacValue != "" {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		_ = r.Body.Close()
+
+		mac := hmac.New(sha256.New, hmacKey)
+		mac.Write(body)
+
+		hmacSigOk = hex.EncodeToString(mac.Sum(nil)) == hmacValue
+	}
+
+	return
+}
+
+func TestWebhook_Handle(t *testing.T) {
+	ev := event.New(event.Event{
+		Namespace: "default",
+		Kind:      "pod",
+		Component: "",
+		Host:      "some-node",
+		Reason:    "created",
+		Status:    "Normal",
+		Name:      "cool-pod",
+	}, "created")
+
+	t.Run("default header", func(t *testing.T) {
+		headerOk := false
+		hmacSigOk := false
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			headerOk, hmacSigOk = checkHeaderAndHMAC([]byte(`123`), "X-KubeWatch-Signature", r)
+			_, _ = w.Write([]byte(`ok`))
+		}))
+		defer srv.Close()
+
+		s := &Webhook{}
+		c := &config.Config{}
+		c.Handler.Webhook = config.Webhook{
+			Url:     srv.URL,
+			HMACKey: "MTIz", // 123
+		}
+
+		if err := s.Init(c); err != nil {
+			t.Fatal(err)
+		}
+
+		s.Handle(ev)
+
+		if !headerOk {
+			t.Fatal("header does not match")
+		}
+		if !hmacSigOk {
+			t.Fatal("hmac signature does not match")
+		}
+	})
+
+	t.Run("custom header", func(t *testing.T) {
+		headerOk := false
+		hmacSigOk := false
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			headerOk, hmacSigOk = checkHeaderAndHMAC([]byte(`123`), "X-Custom-Header", r)
+			_, _ = w.Write([]byte(`ok`))
+		}))
+		defer srv.Close()
+
+		s := &Webhook{}
+		c := &config.Config{}
+		c.Handler.Webhook = config.Webhook{
+			Url:                 srv.URL,
+			HMACKey:             "MTIz", // 123
+			HMACSignatureHeader: "X-Custom-Header",
+		}
+
+		if err := s.Init(c); err != nil {
+			t.Fatal(err)
+		}
+
+		s.Handle(ev)
+
+		if !headerOk {
+			t.Fatal("header does not match")
+		}
+		if !hmacSigOk {
+			t.Fatal("hmac signature does not match")
+		}
+	})
 }


### PR DESCRIPTION
A common webhook use case is to include an HMAC header that is a signature of the body to verify it hasn't been tampered with. This PR adds that functionality. There are 2 new config values for the `Webhook` section:

- `HMACKey`: a base64 encoded hmac key to generate the hmac signature with
- `HMACSignatureHeader`: a custom http header to set the hamc signature to (defaults to `X-KubeWatch-Signature`)