### PR TITLE
Add host field into the metadata in webhook handler

### DIFF
--- a/pkg/handlers/webhook/webhook.go
+++ b/pkg/handlers/webhook/webhook.go
@@ -61,6 +61,7 @@ type EventMeta struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
 	Reason    string `json:"reason"`
+	Host      string `json:"host,omitempty"`
 }
 
 // Init prepares Webhook configuration
@@ -104,6 +105,7 @@ func prepareWebhookMessage(e event.Event, m *Webhook) *WebhookMessage {
 			Name:      e.Name,
 			Namespace: e.Namespace,
 			Reason:    e.Reason,
+			Host:      e.Host,
 		},
 		Text: e.Message(),
 		Time: time.Now(),


### PR DESCRIPTION
The Kubewatch event contains the Host field which seems to be correctly filled in for Pod resource type. Even though there is such a field present, the webhook (and other handlers) do not publish it. This feature adds the Host field into the EventMeta that are published through webhook handler.