### PR TITLE
current docker image requires config location

### DIFF
--- a/kubewatch.yaml
+++ b/kubewatch.yaml
@@ -8,6 +8,9 @@ spec:
   - image: bitnami/kubewatch #using this image, its more stable and active
     imagePullPolicy: Always
     name: kubewatch
+    env:
+    - name: KW_CONFIG
+      value: /root
     volumeMounts:
     - name: config-volume
       mountPath: /root


### PR DESCRIPTION
the current bitnami dockerfile and entrypoint.sh use the KW_CONFIG env variable to locate the kubewatch.yml config file.
The alternative `HOME` is set to '/'.